### PR TITLE
Cleanup LuaScript tests

### DIFF
--- a/src/main/java/li/chee/vertx/reststorage/FileSystemStorage.java
+++ b/src/main/java/li/chee/vertx/reststorage/FileSystemStorage.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import org.vertx.java.core.AsyncResult;
@@ -228,4 +229,8 @@ public class FileSystemStorage implements Storage {
         // nothing to do here
     }
 
+    @Override
+    public void getExpand(String path, String etag, List<String> subResources, Handler<Resource> handler) {
+        throw new UnsupportedOperationException("Method 'getExpand' is not yet implemented for the FileSystemStorage");
+    }
 }

--- a/src/main/java/li/chee/vertx/reststorage/Storage.java
+++ b/src/main/java/li/chee/vertx/reststorage/Storage.java
@@ -2,9 +2,13 @@ package li.chee.vertx.reststorage;
 
 import org.vertx.java.core.Handler;
 
+import java.util.List;
+
 public interface Storage {
 
     void get(String path, String etag, int offset, int count, Handler<Resource> handler);
+
+    void getExpand(String path, String etag, List<String> subResources, Handler<Resource> handler);
 
     void put(String path, String etag, boolean merge, long expire, Handler<Resource> handler);
 

--- a/src/main/resources/getExpand.lua
+++ b/src/main/resources/getExpand.lua
@@ -59,4 +59,4 @@ for i=1,subResourcesCount do
     end
 end
 
-return result
+return cjson.encode(result)

--- a/src/main/resources/getExpand.lua
+++ b/src/main/resources/getExpand.lua
@@ -59,4 +59,10 @@ for i=1,subResourcesCount do
     end
 end
 
-return cjson.encode(result)
+local resEncoded = cjson.encode(result)
+
+if (resEncoded=='{}') then
+    return "notFound"
+end
+
+return resEncoded

--- a/src/main/resources/getExpand.lua
+++ b/src/main/resources/getExpand.lua
@@ -43,7 +43,7 @@ for i=1,subResourcesCount do
         local colPath = collectionsPrefix..path..sep..subResName
         if redis.call('exists',colPath) == 1 then
             local colMembers = redis.call('zrangebyscore',colPath, timestamp, maxtime)
-            table.insert(result, cjson.encode(colMembers))
+            table.insert(result, {subResName, cjson.encode(colMembers)})
         end
     else
         local resPath = resourcesPrefix..path..sep..subResName
@@ -52,7 +52,7 @@ for i=1,subResourcesCount do
             if score == nil or score > timestamp then
                 local res = (redis.call('hget',resPath,'resource'))
                 if(res) then
-                    table.insert(result, res)
+                    table.insert(result, {subResName, res})
                 end
             end
         end

--- a/src/main/resources/getExpand.lua
+++ b/src/main/resources/getExpand.lua
@@ -1,0 +1,62 @@
+-- --------------------------------------------------------------------------------------------
+-- Copyright 2014 by Swiss Post, Information Technology Services
+-- --------------------------------------------------------------------------------------------
+-- $Id$
+-- --------------------------------------------------------------------------------------------
+
+local sep = ":"
+local path = KEYS[1]
+local parentPathElement
+local resourcesPrefix = ARGV[1]
+local collectionsPrefix = ARGV[2]
+local expirableSet = ARGV[3]
+local timestamp = tonumber(ARGV[4])
+local maxtime = tonumber(ARGV[5])
+local subResources = ARGV[6]
+local subResourcesCount = tonumber(ARGV[7])
+
+local function splitToTable(divider,str)
+    if (divider=='') then return false end
+    local pos,arr = 0,{}
+    for st,sp in function() return string.find(str,divider,pos,true) end do
+        table.insert(arr,string.sub(str,pos,st-1))
+        pos = sp + 1
+    end
+    table.insert(arr,string.sub(str,pos))
+    return arr
+end
+
+local function isCollection(resName)
+    if(string.find(resName, "/", -1) ~= nil) then
+        return true
+    end
+    return false
+end
+
+local result = {}
+local subResourcesTable = splitToTable(";", subResources);
+
+for i=1,subResourcesCount do
+    local subResName = subResourcesTable[i]
+    if(isCollection(subResName)) then
+        subResName = string.sub(subResName, 1, string.len(subResName)-1)
+        local colPath = collectionsPrefix..path..sep..subResName
+        if redis.call('exists',colPath) == 1 then
+            local colMembers = redis.call('zrangebyscore',colPath, timestamp, maxtime)
+            table.insert(result, cjson.encode(colMembers))
+        end
+    else
+        local resPath = resourcesPrefix..path..sep..subResName
+        if redis.call('exists',resPath) == 1 then
+            local score = tonumber(redis.call('zscore',expirableSet,resPath))
+            if score == nil or score > timestamp then
+                local res = (redis.call('hget',resPath,'resource'))
+                if(res) then
+                    table.insert(result, res)
+                end
+            end
+        end
+    end
+end
+
+return result

--- a/src/test/java/li/chee/vertx/reststorage/ExpandInStorageTest.java
+++ b/src/test/java/li/chee/vertx/reststorage/ExpandInStorageTest.java
@@ -1,0 +1,253 @@
+/*
+ * ------------------------------------------------------------------------------------------------
+ * Copyright 2014 by Swiss Post, Information Technology Services
+ * ------------------------------------------------------------------------------------------------
+ * $Id$
+ * ------------------------------------------------------------------------------------------------
+ */
+
+package li.chee.vertx.reststorage;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.response.Response;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.jayway.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+import static org.vertx.testtools.VertxAssert.testComplete;
+
+
+public class ExpandInStorageTest extends AbstractTestCase {
+
+    final String ETAG_HEADER = "Etag";
+    final String IF_NONE_MATCH_HEADER = "if-none-match";
+    final String POST_STORAGE_EXP = "/server/resources?expandInStorage=true";
+
+    @Before
+    public void setPath() {
+        RestAssured.basePath = "/server/resources";
+        delete("/");
+    }
+
+    @Test
+    public void testPOSTWithoutExpandParam() {
+        given()
+                .body("{ \"foo\": \"bar1\" }")
+                .when()
+                .post("/server/resources")
+                .then()
+                .assertThat().statusCode(405);
+
+        testComplete();
+    }
+
+    @Test
+    public void testPOSTWithWrongBody() {
+        given()
+                .body("{ \"foo\": \"bar1\" }")
+                .when()
+                .post(POST_STORAGE_EXP)
+                .then()
+                .assertThat().statusCode(400)
+                .assertThat().body(equalTo("Bad Request: Expected array field 'subResources' with names of resources"));
+
+        testComplete();
+    }
+
+    @Test
+    public void testSimpleWith3Resources() {
+
+        delete("/server/resources");
+
+        with().body("{ \"foo\": \"bar1\" }").put("/server/resources/res1");
+        with().body("{ \"foo\": \"bar2\" }").put("/server/resources/res2");
+        with().body("{ \"foo\": \"bar3\" }").put("/server/resources/res3");
+
+        given()
+                .body("{ \"subResources\": [\"res1\", \"res2\", \"res3\"] }")
+                .when()
+                .post(POST_STORAGE_EXP)
+                .then()
+                .assertThat().statusCode(200).contentType(ContentType.JSON).header(ETAG_HEADER, not(empty()))
+                .body("", hasKey("resources"))
+                .body("resources", allOf(hasKey("res1"), hasKey("res2"), hasKey("res3")))
+                .body("resources.res1.foo", equalTo("bar1"))
+                .body("resources.res2.foo", equalTo("bar2"))
+                .body("resources.res3.foo", equalTo("bar3"));
+
+        testComplete();
+    }
+
+    @Test
+    public void testSimpleWithUnknownSubResources() {
+
+        delete("/server/resources");
+
+        with().body("{ \"foo\": \"bar1\" }").put("/server/resources/res1");
+        with().body("{ \"foo\": \"bar2\" }").put("/server/resources/res2");
+        with().body("{ \"foo\": \"bar3\" }").put("/server/resources/res3");
+
+        given()
+                .body("{ \"subResources\": [\"res1\", \"res2XX\", \"res3\"] }")
+                .when()
+                .post(POST_STORAGE_EXP)
+                .then()
+                .assertThat().statusCode(200).contentType(ContentType.JSON).header(ETAG_HEADER, not(empty()))
+                .body("", hasKey("resources"))
+                .body("resources", allOf(hasKey("res1"), hasKey("res3")))
+                .body("resources", not(hasKey("res2")))
+                .body("resources.res1.foo", equalTo("bar1"))
+                .body("resources.res3.foo", equalTo("bar3"));
+
+        testComplete();
+    }
+
+    @Test
+    public void testSimpleWithMissingSubResources() {
+
+        delete("/server/resources");
+
+        with().body("{ \"foo\": \"bar1\" }").put("/server/resources/res1");
+        with().body("{ \"foo\": \"bar3\" }").put("/server/resources/res3");
+
+        given()
+                .body("{ \"subResources\": [\"res1\", \"res2\", \"res3\"] }")
+                .when()
+                .post(POST_STORAGE_EXP)
+                .then()
+                .assertThat().statusCode(200).contentType(ContentType.JSON).header(ETAG_HEADER, not(empty()))
+                .body("", hasKey("resources"))
+                .body("resources", allOf(hasKey("res1"), hasKey("res3")))
+                .body("resources", not(hasKey("res2")))
+                .body("resources.res1.foo", equalTo("bar1"))
+                .body("resources.res3.foo", equalTo("bar3"));
+
+        testComplete();
+    }
+
+    @Test
+    public void testSimpleWithEmptyResult() {
+
+        delete("/server/resources");
+
+        given()
+                .body("{ \"subResources\": [\"res1\", \"res2\", \"res3\"] }")
+                .when()
+                .post(POST_STORAGE_EXP)
+                .then()
+                .assertThat().statusCode(404);
+
+        testComplete();
+    }
+
+    @Test
+    public void testSimpleWithResourcesAndCollections() {
+
+        delete("/server/resources");
+
+        with().body("{ \"foo\": \"bar1\" }").put("/server/resources/res1");
+        with().body("{ \"foo\": \"bar2\" }").put("/server/resources/res2");
+        with().body("{ \"foo\": \"bar3\" }").put("/server/resources/res3");
+        with().body("{ \"foo\": \"sub1\" }").put("/server/resources/sub/sub1");
+        with().body("{ \"foo\": \"sub2\" }").put("/server/resources/sub/sub2");
+
+        given()
+                .body("{ \"subResources\": [\"res1\", \"res2\", \"res3\", \"sub/\"] }")
+                .when()
+                .post(POST_STORAGE_EXP)
+                .then()
+                .assertThat().statusCode(200).contentType(ContentType.JSON).header(ETAG_HEADER, not(empty()))
+                .body("", hasKey("resources"))
+                .body("resources", allOf(hasKey("res1"), hasKey("res2"), hasKey("res3"), hasKey("sub")))
+                .body("resources.res1.foo", equalTo("bar1"))
+                .body("resources.res2.foo", equalTo("bar2"))
+                .body("resources.res3.foo", equalTo("bar3"))
+                .body("resources.sub", hasItems("sub1", "sub2"));
+
+        delete("/server/resources");
+
+        with().body("{ \"foo\": \"sub1\" }").put("/server/resources/sub/sub1");
+        with().body("{ \"foo\": \"sub2\" }").put("/server/resources/sub/sub2");
+        with().body("{ \"foo\": \"sub2\" }").put("/server/resources/anothersub/sub3");
+        with().body("{ \"foo\": \"sub2\" }").put("/server/resources/anothersub/sub4");
+
+        given()
+                .body("{ \"subResources\": [\"anothersub/\", \"sub/\"] }")
+                .when()
+                .post(POST_STORAGE_EXP)
+                .then()
+                .assertThat().statusCode(200).contentType(ContentType.JSON).header(ETAG_HEADER, not(empty()))
+                .body("", hasKey("resources"))
+                .body("resources", allOf(hasKey("anothersub"), hasKey("sub")))
+                .body("resources.sub", hasItems("sub1", "sub2"))
+                .body("resources.anothersub", hasItems("sub3", "sub4"));
+
+        testComplete();
+    }
+
+    @Test
+    public void testSameEtagForSameResult() {
+
+        delete("/server/resources");
+
+        with().body("{ \"foo\": \"bar1\" }").put("/server/resources/res1");
+        with().body("{ \"foo\": \"bar2\" }").put("/server/resources/res2");
+        with().body("{ \"foo\": \"bar3\" }").put("/server/resources/res3");
+
+        Response post1 = given()
+                .body("{ \"subResources\": [\"res1\", \"res2\", \"res3\"] }")
+                .when()
+                .post(POST_STORAGE_EXP);
+        String etagPost1 = post1.getHeader(ETAG_HEADER);
+
+        Response post2 = given()
+                .body("{ \"subResources\": [\"res1\", \"res2\", \"res3\"] }")
+                .when()
+                .post(POST_STORAGE_EXP);
+        String etagPost2 = post2.getHeader(ETAG_HEADER);
+
+        Response post3 = given()
+                .body("{ \"subResources\": [\"res1\", \"res2\"] }")
+                .when()
+                .post(POST_STORAGE_EXP);
+        String etagPost3 = post3.getHeader(ETAG_HEADER);
+
+        Assert.assertEquals(etagPost1, etagPost2);
+        Assert.assertNotEquals(etagPost2, etagPost3);
+
+        testComplete();
+    }
+
+    @Test
+    public void testIfNoneMatchHeaderProvided() {
+
+        delete("/server/resources");
+
+        with().body("{ \"foo\": \"bar1\" }").put("/server/resources/res1");
+        with().body("{ \"foo\": \"bar2\" }").put("/server/resources/res2");
+        with().body("{ \"foo\": \"bar3\" }").put("/server/resources/res3");
+
+        String etag = "SomeEtagValue";
+
+        Response post1 = given().header(IF_NONE_MATCH_HEADER, etag)
+                .body("{ \"subResources\": [\"res1\", \"res2\", \"res3\"] }")
+                .when()
+                .post(POST_STORAGE_EXP);
+        String etagPost1 = post1.getHeader(ETAG_HEADER);
+
+        Assert.assertNotNull(etagPost1);
+        Assert.assertNotEquals(etagPost1, etag);
+
+        given().header(IF_NONE_MATCH_HEADER, etagPost1)
+                .body("{ \"subResources\": [\"res1\", \"res2\", \"res3\"] }")
+                .when()
+                .post(POST_STORAGE_EXP)
+                .then()
+                .assertThat().statusCode(304);
+
+        testComplete();
+    }
+}

--- a/src/test/java/li/chee/vertx/reststorage/lua/AbstractLuaScriptTest.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/AbstractLuaScriptTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractLuaScriptTest {
     }
 
     @After
-    public void disconnnect() {
+    public void disconnect() {
         jedis.flushAll();
         jedis.close();
     }

--- a/src/test/java/li/chee/vertx/reststorage/lua/AbstractLuaScriptTest.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/AbstractLuaScriptTest.java
@@ -18,6 +18,8 @@ import redis.clients.jedis.Jedis;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.UUID;
 
 /**
  * Abstract class containing common methods for LuaScript tests
@@ -30,18 +32,20 @@ public abstract class AbstractLuaScriptTest {
     final static String prefixDeltaResources = "delta:resources";
     final static String prefixDeltaEtags = "delta:etags";
 
+    public static final String MAX_EXPIRE = "9999999999999";
+
     Jedis jedis = null;
 
     @BeforeClass
     public static void config() {
-        if(!useExternalRedis()) {
+        if (!useExternalRedis()) {
             RedisEmbeddedConfiguration.redisServer.start();
         }
     }
 
     @AfterClass
     public static void stopRedis() {
-        if(!useExternalRedis()) {
+        if (!useExternalRedis()) {
             RedisEmbeddedConfiguration.redisServer.stop();
         }
     }
@@ -63,10 +67,12 @@ public abstract class AbstractLuaScriptTest {
     }
 
     protected double getNowAsDouble() {
-        return Double.valueOf(System.currentTimeMillis()).doubleValue();
+        return (double) System.currentTimeMillis();
     }
 
-    protected String getNowAsString() { return String.valueOf(System.currentTimeMillis()); }
+    protected String getNowAsString() {
+        return String.valueOf(System.currentTimeMillis());
+    }
 
     protected String readScript(String scriptFileName) {
         return readScript(scriptFileName, false);
@@ -96,4 +102,42 @@ public abstract class AbstractLuaScriptTest {
         }
         return sb.toString();
     }
+
+    protected String evalScriptPut(final String resourceName, final String resourceValue) {
+        return evalScriptPut(resourceName, resourceValue, MAX_EXPIRE);
+    }
+
+    protected String evalScriptPut(final String resourceName, final String resourceValue, final String expire) {
+        return evalScriptPut(resourceName, resourceValue, expire, UUID.randomUUID().toString());
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked", "serial"})
+    protected String evalScriptPut(final String resourceName, final String resourceValue, final String expire, final String etag) {
+        String putScript = readScript("put.lua");
+        String etagTmp;
+        if (etag != null && !etag.isEmpty()) {
+            etagTmp = etag;
+        } else {
+            etagTmp = UUID.randomUUID().toString();
+        }
+        final String etagValue = etagTmp;
+        return (String) jedis.eval(putScript, new ArrayList() {
+                    {
+                        add(resourceName);
+                    }
+                }, new ArrayList() {
+                    {
+                        add(prefixResources);
+                        add(prefixCollections);
+                        add(expirableSet);
+                        add("false");
+                        add(expire);
+                        add("9999999999999");
+                        add(resourceValue);
+                        add(etagValue);
+                    }
+                }
+        );
+    }
+
 }

--- a/src/test/java/li/chee/vertx/reststorage/lua/AbstractLuaScriptTest.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/AbstractLuaScriptTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractLuaScriptTest {
     final static String prefixDeltaResources = "delta:resources";
     final static String prefixDeltaEtags = "delta:etags";
 
-    public static final String MAX_EXPIRE = "9999999999999";
+    static final String MAX_EXPIRE = "9999999999999";
 
     Jedis jedis = null;
 
@@ -140,4 +140,36 @@ public abstract class AbstractLuaScriptTest {
         );
     }
 
+    protected Object evalScriptGet(final String resourceName) {
+        return evalScriptGet(resourceName, String.valueOf(System.currentTimeMillis()));
+    }
+
+    protected Object evalScriptGet(final String resourceName, final String timestamp) {
+        return evalScriptGet(resourceName, timestamp, "", "");
+    }
+
+    protected Object evalScriptGetOffsetCount(final String resourceName1, final String offset, final String count) {
+        return evalScriptGet(resourceName1, String.valueOf(System.currentTimeMillis()), offset, count);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
+    protected Object evalScriptGet(final String resourceName, final String timestamp, final String offset, final String count) {
+        String getScript = readScript("get.lua");
+        return jedis.eval(getScript, new ArrayList() {
+                    {
+                        add(resourceName);
+                    }
+                }, new ArrayList() {
+                    {
+                        add(prefixResources);
+                        add(prefixCollections);
+                        add(expirableSet);
+                        add(timestamp);
+                        add("9999999999999");
+                        add(offset);
+                        add(count);
+                    }
+                }
+        );
+    }
 }

--- a/src/test/java/li/chee/vertx/reststorage/lua/JedisFactory.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/JedisFactory.java
@@ -5,7 +5,7 @@ import redis.clients.jedis.Jedis;
 /**
  * Created by kammermannf on 07.06.2015.
  */
-public class JedisFactory {
+class JedisFactory {
 
     public static Jedis createJedis() {
         return new Jedis("localhost", 6379, 5000);

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisCleanupLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisCleanupLuaScriptTests.java
@@ -46,7 +46,7 @@ public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
     }
 
     @After
-    public void disconnnect() {
+    public void disconnect() {
         jedis.flushAll();
         jedis.close();
     }

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisCleanupLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisCleanupLuaScriptTests.java
@@ -56,8 +56,8 @@ public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
 
         // ARRANGE
         String now = String.valueOf(System.currentTimeMillis());
-        evalScriptPut(":project:server:test:test1:test2", "{\"content\": \"test/test1/test2\"}", now);
-        evalScriptPut(":project:server:test:test11:test22", "{\"content\": \"test/test1/test2\"}", now);
+        evalScriptPutNoReturn(":project:server:test:test1:test2", "{\"content\": \"test/test1/test2\"}", now);
+        evalScriptPutNoReturn(":project:server:test:test11:test22", "{\"content\": \"test/test1/test2\"}", now);
         Thread.sleep(10);
 
         // ACT
@@ -80,8 +80,8 @@ public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
         // ARRANGE
         String now = String.valueOf(System.currentTimeMillis());
         String nowPlus1000sec = String.valueOf((System.currentTimeMillis() + 1000000));
-        evalScriptPut(":project:server:test:test1:test2", "{\"content\": \"test/test1/test2\"}", now);
-        evalScriptPut(":project:server:test:test11:test22", "{\"content\": \"test/test1/test2\"}", nowPlus1000sec);
+        evalScriptPutNoReturn(":project:server:test:test1:test2", "{\"content\": \"test/test1/test2\"}", now);
+        evalScriptPutNoReturn(":project:server:test:test11:test22", "{\"content\": \"test/test1/test2\"}", nowPlus1000sec);
         Thread.sleep(1000);
 
         // ACT
@@ -107,7 +107,7 @@ public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
         String now = String.valueOf(System.currentTimeMillis());
         String maxExpire = String.valueOf(MAX_EXPIRE_IN_MILLIS);
         for (int i = 1; i <= 30; i++) {
-            evalScriptPut(":project:server:test:test1:test" + i, "{\"content\": \"test" + i + "\"}", i % 2 == 0 ? now : maxExpire);
+            evalScriptPutNoReturn(":project:server:test:test1:test" + i, "{\"content\": \"test" + i + "\"}", i % 2 == 0 ? now : maxExpire);
         }
         Thread.sleep(10);
 
@@ -128,7 +128,7 @@ public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
         String now = String.valueOf(System.currentTimeMillis());
         String maxExpire = String.valueOf(MAX_EXPIRE_IN_MILLIS);
         for (int i = 1; i <= 21000; i++) {
-            evalScriptPut(":project:server:test:test1:test" + i, "{\"content\": \"test" + i + "\"}", i % 3 == 0 ? now : maxExpire);
+            evalScriptPutNoReturn(":project:server:test:test1:test" + i, "{\"content\": \"test" + i + "\"}", i % 3 == 0 ? now : maxExpire);
         }
         Thread.sleep(100);
 
@@ -185,28 +185,6 @@ public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
         assertThat(jedis.zcount("rest-storage:collections:project:server:test:test1", getNowAsDouble(), MAX_EXPIRE_IN_MILLIS), equalTo(1000000l));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private void evalScriptPut(final String resourceName1, final String resourceValue1, final String expire) {
-        String putScript = readScript("put.lua", true);
-        jedis.eval(putScript, new ArrayList() {
-                    {
-                        add(resourceName1);
-                    }
-                }, new ArrayList() {
-                    {
-                        add(prefixResources);
-                        add(prefixCollections);
-                        add(expirableSet);
-                        add("false");
-                        add(expire);
-                        add("9999999999999");
-                        add(resourceValue1);
-                        add(UUID.randomUUID().toString());
-                    }
-                }
-        );
-    }
-
     private Object evalScriptCleanup(final long minscore, final long now) {
         return evalScriptCleanup(minscore, now, 1000, false);
     }
@@ -256,6 +234,28 @@ public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
                         add(expirableSet);
                         add(getNowAsString());
                         add(String.valueOf(maxscore));
+                    }
+                }
+        );
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
+    private void evalScriptPutNoReturn(final String resourceName, final String resourceValue, final String expire) {
+        String putScript = readScript("put.lua", true);
+        jedis.eval(putScript, new ArrayList() {
+                    {
+                        add(resourceName);
+                    }
+                }, new ArrayList() {
+                    {
+                        add(prefixResources);
+                        add(prefixCollections);
+                        add(expirableSet);
+                        add("false");
+                        add(expire);
+                        add("9999999999999");
+                        add(resourceValue);
+                        add(UUID.randomUUID().toString());
                     }
                 }
         );

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisCleanupLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisCleanupLuaScriptTests.java
@@ -219,27 +219,6 @@ public class RedisCleanupLuaScriptTests extends AbstractLuaScriptTest {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private Object evalScriptDel(final String resourceName, final double maxscore) {
-        String delScript = readScript("del.lua", false);
-        return jedis.eval(delScript, new ArrayList() {
-                    {
-                        add(resourceName);
-                    }
-                }, new ArrayList() {
-                    {
-                        add(prefixResources);
-                        add(prefixCollections);
-                        add(prefixDeltaResources);
-                        add(prefixDeltaEtags);
-                        add(expirableSet);
-                        add(getNowAsString());
-                        add(String.valueOf(maxscore));
-                    }
-                }
-        );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
     private void evalScriptPutNoReturn(final String resourceName, final String resourceValue, final String expire) {
         String putScript = readScript("put.lua", true);
         jedis.eval(putScript, new ArrayList() {

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisDelLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisDelLuaScriptTests.java
@@ -3,7 +3,6 @@ package li.chee.vertx.reststorage.lua;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -118,12 +117,11 @@ public class RedisDelLuaScriptTests extends AbstractLuaScriptTest {
     public void deleteExpiredResourceWithMaxScoreAtMax() throws InterruptedException {
 
         // ARRANGE
-        String now = String.valueOf(System.currentTimeMillis());
         evalScriptPut(":project:server:test:test1:test2", "{\"content\": \"test/test1/test2\"}", "9999999999999");
         Thread.sleep(10);
 
         // ACT
-        String value = (String) evalScriptDel(":project:server:test:test1:test2");
+        evalScriptDel(":project:server:test:test1:test2");
 
         // ASSERT
         assertThat(jedis.zrangeByScore("rest-storage:collections:project", getNowAsDouble(), 9999999999999d).size(), equalTo(0));
@@ -147,7 +145,7 @@ public class RedisDelLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         long after = System.currentTimeMillis();
-        String value = (String) evalScriptDel(":project:server:test:test1:test2", after);
+        evalScriptDel(":project:server:test:test1:test2", after);
 
         // ASSERT
         assertThat(jedis.zrangeByScore("rest-storage:collections:project", getNowAsDouble(), 9999999999999d).size(), equalTo(0));
@@ -172,7 +170,7 @@ public class RedisDelLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         long after = System.currentTimeMillis();
-        String value = (String) evalScriptDel(":project:server:test:test1:test2", after);
+        evalScriptDel(":project:server:test:test1:test2", after);
 
         // ASSERT
         String afterNow = String.valueOf(System.currentTimeMillis());
@@ -195,7 +193,7 @@ public class RedisDelLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         long after = System.currentTimeMillis();
-        String value = (String) evalScriptDel(":project:server:test:test11:test22", after);
+        evalScriptDel(":project:server:test:test11:test22", after);
 
         // ASSERT
         assertThat(jedis.exists("rest-storage:collections:project"), equalTo(true));
@@ -203,25 +201,6 @@ public class RedisDelLuaScriptTests extends AbstractLuaScriptTest {
         assertThat(jedis.exists("rest-storage:collections:project:server:test"), equalTo(true));
         assertThat(jedis.exists("rest-storage:collections:project:server:test:test11"), equalTo(false));
         assertThat(jedis.exists("rest-storage:resources:project:server:test:test11:test22"), equalTo(false));
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private Object evalScriptGet(final String resourceName1, final String timestamp) {
-        String getScript = readScript("get.lua");
-        return jedis.eval(getScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add(timestamp);
-                add("9999999999999");
-            }
-        }
-                );
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked", "serial" })

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisDelLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisDelLuaScriptTests.java
@@ -206,50 +206,6 @@ public class RedisDelLuaScriptTests extends AbstractLuaScriptTest {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private void evalScriptPut(final String resourceName1, final String resourceValue1) {
-        String putScript = readScript("put.lua");
-        jedis.eval(putScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add("false");
-                add("9999999999999");
-                add("9999999999999");
-                add(resourceValue1);
-                add(UUID.randomUUID().toString());
-            }
-        }
-                );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private void evalScriptPut(final String resourceName1, final String resourceValue1, final String expire) {
-        String putScript = readScript("put.lua");
-        jedis.eval(putScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add("false");
-                add(expire);
-                add("9999999999999");
-                add(resourceValue1);
-                add(UUID.randomUUID().toString());
-            }
-        }
-                );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
     private Object evalScriptGet(final String resourceName1, final String timestamp) {
         String getScript = readScript("get.lua");
         return jedis.eval(getScript, new ArrayList() {

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
@@ -8,6 +8,7 @@
 
 package li.chee.vertx.reststorage.lua;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -237,7 +238,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
                         add(expirableSet);
                         add(timestamp);
                         add("9999999999999");
-                        add(String.join(";", subResources));
+                        add(StringUtils.join(subResources, ";"));
                         add(String.valueOf(subResources.size()));
                     }
                 }

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
@@ -288,7 +288,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
             valueStr = (String) evalScriptGetExpand(resourceName, subResources);
         }
 
-        if(valueStr.equals("{}")){
+        if(valueStr.equals("notFound")){
             return result;
         }
 

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
@@ -10,6 +10,7 @@ package li.chee.vertx.reststorage.lua;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
+import org.vertx.java.core.json.JsonArray;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("item2", "item1", "item3");
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(3));
@@ -52,7 +53,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
 
         // ACT
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", new ArrayList<String>());
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", new ArrayList<String>());
 
         // ASSERT
         assertNotNull(value);
@@ -71,7 +72,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("sub/", "item1", "item2", "item3");
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(4));
@@ -94,7 +95,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("sub/");
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(1));
@@ -103,7 +104,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         subResources = Arrays.asList("subsub/");
-        value = (List<List<String>>)  evalScriptGetExpand(":project:server:test:sub", subResources);
+        value = evalScriptGetExpandAndExtract(":project:server:test:sub", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(1));
@@ -112,7 +113,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         subResources = Arrays.asList("item1", "item2");
-        value = (List<List<String>>) evalScriptGetExpand(":project:server:test:sub:subsub", subResources);
+        value = evalScriptGetExpandAndExtract(":project:server:test:sub:subsub", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(2));
@@ -133,7 +134,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("sub/", "anothersub/");
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(2));
@@ -153,7 +154,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("item2x", "item1x", "item3x");
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", subResources);
 
         // ASSERT
         assertNotNull(value);
@@ -170,7 +171,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("item3", "invalidItem", "item1");
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(2));
@@ -181,7 +182,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         subResources = Arrays.asList("item3", "invalidSub/");
-        value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
+        value = evalScriptGetExpandAndExtract(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(1));
@@ -203,7 +204,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         String timestamp = String.valueOf(System.currentTimeMillis());
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
 
         // ASSERT
         assertThat(value.size(), equalTo(1));
@@ -214,7 +215,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         timestamp = String.valueOf(System.currentTimeMillis());
-        value = (List<List<String>>) evalScriptGetExpand(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
+        value = evalScriptGetExpandAndExtract(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
 
         // ASSERT
         assertNotNull(value);
@@ -238,7 +239,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         String timestamp = String.valueOf(System.currentTimeMillis());
-        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", Arrays.asList("sub/", "item1", "item2", "item3"), timestamp);
+        List<List<String>> value = evalScriptGetExpandAndExtract(":project:server:test", Arrays.asList("sub/", "item1", "item2", "item3"), timestamp);
 
         // ASSERT
         assertThat(value.size(), equalTo(2));
@@ -272,5 +273,30 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
                     }
                 }
         );
+    }
+
+    private List<List<String>> evalScriptGetExpandAndExtract(String resourceName, List<String> subResources){
+        return evalScriptGetExpandAndExtract(resourceName, subResources, null);
+    }
+
+    private List<List<String>> evalScriptGetExpandAndExtract(String resourceName, List<String> subResources, String timestamp){
+        List<List<String>> result = new ArrayList<>();
+        String valueStr;
+        if(timestamp != null){
+            valueStr = (String) evalScriptGetExpand(resourceName, subResources, timestamp);
+        } else {
+            valueStr = (String) evalScriptGetExpand(resourceName, subResources);
+        }
+
+        if(valueStr.equals("{}")){
+            return result;
+        }
+
+        JsonArray jsonArray = new JsonArray(valueStr);
+        for (Object arr : jsonArray) {
+            JsonArray subArr = (JsonArray) arr;
+            result.add(Arrays.asList((String)subArr.get(0), (String)subArr.get(1)));
+        }
+        return result;
     }
 }

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
@@ -31,13 +31,16 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("item2", "item1", "item3");
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(3));
-        assertThat(value.get(0), equalTo("{\"content\": \"content_2\"}"));
-        assertThat(value.get(1), equalTo("{\"content\": \"content_1\"}"));
-        assertThat(value.get(2), equalTo("{\"content\": \"content_3\"}"));
+        assertThat(value.get(0).get(0), equalTo("item2"));
+        assertThat(value.get(0).get(1), equalTo("{\"content\": \"content_2\"}"));
+        assertThat(value.get(1).get(0), equalTo("item1"));
+        assertThat(value.get(1).get(1), equalTo("{\"content\": \"content_1\"}"));
+        assertThat(value.get(2).get(0), equalTo("item3"));
+        assertThat(value.get(2).get(1), equalTo("{\"content\": \"content_3\"}"));
     }
 
     @Test
@@ -49,7 +52,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
 
         // ACT
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", new ArrayList<String>());
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", new ArrayList<String>());
 
         // ASSERT
         assertNotNull(value);
@@ -68,14 +71,18 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("sub/", "item1", "item2", "item3");
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(4));
-        assertThat(value.get(0), equalTo("[\"sub1\",\"sub2\"]"));
-        assertThat(value.get(1), equalTo("{\"content\": \"content_1\"}"));
-        assertThat(value.get(2), equalTo("{\"content\": \"content_2\"}"));
-        assertThat(value.get(3), equalTo("{\"content\": \"content_3\"}"));
+        assertThat(value.get(0).get(0), equalTo("sub"));
+        assertThat(value.get(0).get(1), equalTo("[\"sub1\",\"sub2\"]"));
+        assertThat(value.get(1).get(0), equalTo("item1"));
+        assertThat(value.get(1).get(1), equalTo("{\"content\": \"content_1\"}"));
+        assertThat(value.get(2).get(0), equalTo("item2"));
+        assertThat(value.get(2).get(1), equalTo("{\"content\": \"content_2\"}"));
+        assertThat(value.get(3).get(0), equalTo("item3"));
+        assertThat(value.get(3).get(1), equalTo("{\"content\": \"content_3\"}"));
     }
 
     @Test
@@ -87,28 +94,32 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("sub/");
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(1));
-        assertThat(value.get(0), equalTo("[\"subsub\"]"));
+        assertThat(value.get(0).get(0), equalTo("sub"));
+        assertThat(value.get(0).get(1), equalTo("[\"subsub\"]"));
 
         // ACT
         subResources = Arrays.asList("subsub/");
-        value = (List<String>) evalScriptGetExpand(":project:server:test:sub", subResources);
+        value = (List<List<String>>)  evalScriptGetExpand(":project:server:test:sub", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(1));
-        assertThat(value.get(0), equalTo("[\"item1\",\"item2\"]"));
+        assertThat(value.get(0).get(0), equalTo("subsub"));
+        assertThat(value.get(0).get(1), equalTo("[\"item1\",\"item2\"]"));
 
         // ACT
         subResources = Arrays.asList("item1", "item2");
-        value = (List<String>) evalScriptGetExpand(":project:server:test:sub:subsub", subResources);
+        value = (List<List<String>>) evalScriptGetExpand(":project:server:test:sub:subsub", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(2));
-        assertThat(value.get(0), equalTo("{\"content\": \"content_sub_1\"}"));
-        assertThat(value.get(1), equalTo("{\"content\": \"content_sub_2\"}"));
+        assertThat(value.get(0).get(0), equalTo("item1"));
+        assertThat(value.get(0).get(1), equalTo("{\"content\": \"content_sub_1\"}"));
+        assertThat(value.get(1).get(0), equalTo("item2"));
+        assertThat(value.get(1).get(1), equalTo("{\"content\": \"content_sub_2\"}"));
     }
 
     @Test
@@ -122,12 +133,14 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("sub/", "anothersub/");
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(2));
-        assertThat(value.get(0), equalTo("[\"sub1\",\"sub2\"]"));
-        assertThat(value.get(1), equalTo("[\"sub3\",\"sub4\"]"));
+        assertThat(value.get(0).get(0), equalTo("sub"));
+        assertThat(value.get(0).get(1), equalTo("[\"sub1\",\"sub2\"]"));
+        assertThat(value.get(1).get(0), equalTo("anothersub"));
+        assertThat(value.get(1).get(1), equalTo("[\"sub3\",\"sub4\"]"));
     }
 
     @Test
@@ -140,7 +153,7 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("item2x", "item1x", "item3x");
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
 
         // ASSERT
         assertNotNull(value);
@@ -157,20 +170,23 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         List<String> subResources = Arrays.asList("item3", "invalidItem", "item1");
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(2));
-        assertThat(value.get(0), equalTo("{\"content\": \"content_3\"}"));
-        assertThat(value.get(1), equalTo("{\"content\": \"content_1\"}"));
+        assertThat(value.get(0).get(0), equalTo("item3"));
+        assertThat(value.get(0).get(1), equalTo("{\"content\": \"content_3\"}"));
+        assertThat(value.get(1).get(0), equalTo("item1"));
+        assertThat(value.get(1).get(1), equalTo("{\"content\": \"content_1\"}"));
 
         // ACT
         subResources = Arrays.asList("item3", "invalidSub/");
-        value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+        value = (List<List<String>>) evalScriptGetExpand(":project:server:test", subResources);
 
         // ASSERT
         assertThat(value.size(), equalTo(1));
-        assertThat(value.get(0), equalTo("{\"content\": \"content_3\"}"));
+        assertThat(value.get(0).get(0), equalTo("item3"));
+        assertThat(value.get(0).get(1), equalTo("{\"content\": \"content_3\"}"));
     }
 
     @Test
@@ -187,17 +203,18 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         String timestamp = String.valueOf(System.currentTimeMillis());
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
 
         // ASSERT
         assertThat(value.size(), equalTo(1));
-        assertThat(value.get(0), equalTo("{\"content\": \"content_2\"}"));
+        assertThat(value.get(0).get(0), equalTo("item2"));
+        assertThat(value.get(0).get(1), equalTo("{\"content\": \"content_2\"}"));
 
         Thread.sleep(100);
 
         // ACT
         timestamp = String.valueOf(System.currentTimeMillis());
-        value = (List<String>) evalScriptGetExpand(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
+        value = (List<List<String>>) evalScriptGetExpand(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
 
         // ASSERT
         assertNotNull(value);
@@ -221,12 +238,14 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         String timestamp = String.valueOf(System.currentTimeMillis());
-        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", Arrays.asList("sub/", "item1", "item2", "item3"), timestamp);
+        List<List<String>> value = (List<List<String>>) evalScriptGetExpand(":project:server:test", Arrays.asList("sub/", "item1", "item2", "item3"), timestamp);
 
         // ASSERT
         assertThat(value.size(), equalTo(2));
-        assertThat(value.get(0), equalTo("[\"sub2\"]"));
-        assertThat(value.get(1), equalTo("{\"content\": \"content_3\"}"));
+        assertThat(value.get(0).get(0), equalTo("sub"));
+        assertThat(value.get(0).get(1), equalTo("[\"sub2\"]"));
+        assertThat(value.get(1).get(0), equalTo("item3"));
+        assertThat(value.get(1).get(1), equalTo("{\"content\": \"content_3\"}"));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked", "serial"})

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
@@ -29,7 +29,6 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}");
         evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
 
-
         // ACT
         List<String> subResources = Arrays.asList("item2", "item1", "item3");
         List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
@@ -42,6 +41,22 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
     }
 
     @Test
+    public void testGetExpandEmptySubresources() {
+
+        // ARRANGE
+        evalScriptPut(":project:server:test:item1", "{\"content\": \"content_1\"}");
+        evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}");
+        evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
+
+        // ACT
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", new ArrayList<String>());
+
+        // ASSERT
+        assertNotNull(value);
+        assertThat(value.size(), equalTo(0));
+    }
+
+    @Test
     public void testGetExpandWithSubCollections() {
 
         // ARRANGE
@@ -50,7 +65,6 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
         evalScriptPut(":project:server:test:sub:sub1", "{\"content\": \"content_sub_1\"}");
         evalScriptPut(":project:server:test:sub:sub2", "{\"content\": \"content_sub_2\"}");
-
 
         // ACT
         List<String> subResources = Arrays.asList("sub/", "item1", "item2", "item3");
@@ -70,7 +84,6 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
         // ARRANGE
         evalScriptPut(":project:server:test:sub:subsub:item1", "{\"content\": \"content_sub_1\"}");
         evalScriptPut(":project:server:test:sub:subsub:item2", "{\"content\": \"content_sub_2\"}");
-
 
         // ACT
         List<String> subResources = Arrays.asList("sub/");
@@ -107,7 +120,6 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:anothersub:sub3", "{\"content\": \"content_sub_3\"}");
         evalScriptPut(":project:server:test:anothersub:sub4", "{\"content\": \"content_sub_4\"}");
 
-
         // ACT
         List<String> subResources = Arrays.asList("sub/", "anothersub/");
         List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
@@ -126,7 +138,6 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}");
         evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
 
-
         // ACT
         List<String> subResources = Arrays.asList("item2x", "item1x", "item3x");
         List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
@@ -143,7 +154,6 @@ public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:item1", "{\"content\": \"content_1\"}");
         evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}");
         evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
-
 
         // ACT
         List<String> subResources = Arrays.asList("item3", "invalidItem", "item1");

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisGetExpandLuaScriptTests.java
@@ -1,0 +1,246 @@
+/*
+ * ------------------------------------------------------------------------------------------------
+ * Copyright 2014 by Swiss Post, Information Technology Services
+ * ------------------------------------------------------------------------------------------------
+ * $Id$
+ * ------------------------------------------------------------------------------------------------
+ */
+
+package li.chee.vertx.reststorage.lua;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+public class RedisGetExpandLuaScriptTests extends AbstractLuaScriptTest {
+
+    @Test
+    public void testGetExpand() {
+
+        // ARRANGE
+        evalScriptPut(":project:server:test:item1", "{\"content\": \"content_1\"}");
+        evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}");
+        evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
+
+
+        // ACT
+        List<String> subResources = Arrays.asList("item2", "item1", "item3");
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(3));
+        assertThat(value.get(0), equalTo("{\"content\": \"content_2\"}"));
+        assertThat(value.get(1), equalTo("{\"content\": \"content_1\"}"));
+        assertThat(value.get(2), equalTo("{\"content\": \"content_3\"}"));
+    }
+
+    @Test
+    public void testGetExpandWithSubCollections() {
+
+        // ARRANGE
+        evalScriptPut(":project:server:test:item1", "{\"content\": \"content_1\"}");
+        evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}");
+        evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
+        evalScriptPut(":project:server:test:sub:sub1", "{\"content\": \"content_sub_1\"}");
+        evalScriptPut(":project:server:test:sub:sub2", "{\"content\": \"content_sub_2\"}");
+
+
+        // ACT
+        List<String> subResources = Arrays.asList("sub/", "item1", "item2", "item3");
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(4));
+        assertThat(value.get(0), equalTo("[\"sub1\",\"sub2\"]"));
+        assertThat(value.get(1), equalTo("{\"content\": \"content_1\"}"));
+        assertThat(value.get(2), equalTo("{\"content\": \"content_2\"}"));
+        assertThat(value.get(3), equalTo("{\"content\": \"content_3\"}"));
+    }
+
+    @Test
+    public void testGetExpandWithSubSubCollections() {
+
+        // ARRANGE
+        evalScriptPut(":project:server:test:sub:subsub:item1", "{\"content\": \"content_sub_1\"}");
+        evalScriptPut(":project:server:test:sub:subsub:item2", "{\"content\": \"content_sub_2\"}");
+
+
+        // ACT
+        List<String> subResources = Arrays.asList("sub/");
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(1));
+        assertThat(value.get(0), equalTo("[\"subsub\"]"));
+
+        // ACT
+        subResources = Arrays.asList("subsub/");
+        value = (List<String>) evalScriptGetExpand(":project:server:test:sub", subResources);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(1));
+        assertThat(value.get(0), equalTo("[\"item1\",\"item2\"]"));
+
+        // ACT
+        subResources = Arrays.asList("item1", "item2");
+        value = (List<String>) evalScriptGetExpand(":project:server:test:sub:subsub", subResources);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(2));
+        assertThat(value.get(0), equalTo("{\"content\": \"content_sub_1\"}"));
+        assertThat(value.get(1), equalTo("{\"content\": \"content_sub_2\"}"));
+    }
+
+    @Test
+    public void testGetExpandWithCollectionsOnly() {
+
+        // ARRANGE
+        evalScriptPut(":project:server:test:sub:sub1", "{\"content\": \"content_sub_1\"}");
+        evalScriptPut(":project:server:test:sub:sub2", "{\"content\": \"content_sub_2\"}");
+        evalScriptPut(":project:server:test:anothersub:sub3", "{\"content\": \"content_sub_3\"}");
+        evalScriptPut(":project:server:test:anothersub:sub4", "{\"content\": \"content_sub_4\"}");
+
+
+        // ACT
+        List<String> subResources = Arrays.asList("sub/", "anothersub/");
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(2));
+        assertThat(value.get(0), equalTo("[\"sub1\",\"sub2\"]"));
+        assertThat(value.get(1), equalTo("[\"sub3\",\"sub4\"]"));
+    }
+
+    @Test
+    public void testGetExpandWithNoMatchingResources() {
+
+        // ARRANGE
+        evalScriptPut(":project:server:test:item1", "{\"content\": \"content_1\"}");
+        evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}");
+        evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
+
+
+        // ACT
+        List<String> subResources = Arrays.asList("item2x", "item1x", "item3x");
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+
+        // ASSERT
+        assertNotNull(value);
+        assertThat(value.size(), equalTo(0));
+    }
+
+    @Test
+    public void testGetExpandWithInvalidSubresources() {
+
+        // ARRANGE
+        evalScriptPut(":project:server:test:item1", "{\"content\": \"content_1\"}");
+        evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}");
+        evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}");
+
+
+        // ACT
+        List<String> subResources = Arrays.asList("item3", "invalidItem", "item1");
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(2));
+        assertThat(value.get(0), equalTo("{\"content\": \"content_3\"}"));
+        assertThat(value.get(1), equalTo("{\"content\": \"content_1\"}"));
+
+        // ACT
+        subResources = Arrays.asList("item3", "invalidSub/");
+        value = (List<String>) evalScriptGetExpand(":project:server:test", subResources);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(1));
+        assertThat(value.get(0), equalTo("{\"content\": \"content_3\"}"));
+    }
+
+    @Test
+    public void testGetExpandExpired() throws InterruptedException {
+
+        // ARRANGE
+        String now = String.valueOf(System.currentTimeMillis());
+        evalScriptPut(":project:server:test:item1", "{\"content\": \"content_1\"}", now);
+
+        String nowPlus100 = String.valueOf(System.currentTimeMillis() + 100);
+        evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}", nowPlus100);
+
+        Thread.sleep(15);
+
+        // ACT
+        String timestamp = String.valueOf(System.currentTimeMillis());
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(1));
+        assertThat(value.get(0), equalTo("{\"content\": \"content_2\"}"));
+
+        Thread.sleep(100);
+
+        // ACT
+        timestamp = String.valueOf(System.currentTimeMillis());
+        value = (List<String>) evalScriptGetExpand(":project:server:test", Arrays.asList("item1", "item2"), timestamp);
+
+        // ASSERT
+        assertNotNull(value);
+        assertThat(value.size(), equalTo(0));
+    }
+
+    @Test
+    public void testGetExpandExpiredWithCollections() throws InterruptedException {
+
+        // ARRANGE
+        String now = String.valueOf(System.currentTimeMillis());
+        String nowPlus1000 = String.valueOf(System.currentTimeMillis() + 1000);
+
+        evalScriptPut(":project:server:test:item1", "{\"content\": \"content_1\"}", now);
+        evalScriptPut(":project:server:test:item2", "{\"content\": \"content_2\"}", now);
+        evalScriptPut(":project:server:test:item3", "{\"content\": \"content_3\"}", nowPlus1000);
+        evalScriptPut(":project:server:test:sub:sub1", "{\"content\": \"content_sub_1\"}", now);
+        evalScriptPut(":project:server:test:sub:sub2", "{\"content\": \"content_sub_2\"}", nowPlus1000);
+
+        Thread.sleep(15);
+
+        // ACT
+        String timestamp = String.valueOf(System.currentTimeMillis());
+        List<String> value = (List<String>) evalScriptGetExpand(":project:server:test", Arrays.asList("sub/", "item1", "item2", "item3"), timestamp);
+
+        // ASSERT
+        assertThat(value.size(), equalTo(2));
+        assertThat(value.get(0), equalTo("[\"sub2\"]"));
+        assertThat(value.get(1), equalTo("{\"content\": \"content_3\"}"));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked", "serial"})
+    private Object evalScriptGetExpand(final String resourceName1, final List<String> subResources) {
+        return evalScriptGetExpand(resourceName1, subResources, String.valueOf(System.currentTimeMillis()));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked", "serial"})
+    private Object evalScriptGetExpand(final String resourceName1, final List<String> subResources, final String timestamp) {
+        String getScript = readScript("getExpand.lua");
+        return jedis.eval(getScript, new ArrayList() {
+                    {
+                        add(resourceName1);
+                    }
+                }, new ArrayList() {
+                    {
+                        add(prefixResources);
+                        add(prefixCollections);
+                        add(expirableSet);
+                        add(timestamp);
+                        add("9999999999999");
+                        add(String.join(";", subResources));
+                        add(String.valueOf(subResources.size()));
+                    }
+                }
+        );
+    }
+}

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisGetLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisGetLuaScriptTests.java
@@ -2,9 +2,7 @@ package li.chee.vertx.reststorage.lua;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
@@ -162,7 +160,7 @@ public class RedisGetLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:test1:test5", "{\"content\": \"test/test1/test5\"}");
 
         // ACT
-        List<String> valuesTest1 = (List<String>) evalScriptGet(":project:server:test:test1", "bla", "blo");
+        List<String> valuesTest1 = (List<String>) evalScriptGetOffsetCount(":project:server:test:test1", "bla", "blo");
 
         // ASSERT
         assertThat(valuesTest1.size(), equalTo(5));
@@ -179,7 +177,7 @@ public class RedisGetLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:test1:test5", "{\"content\": \"test/test1/test5\"}");
 
         // ACT
-        List<String> valuesTest1 = (List<String>) evalScriptGet(":project:server:test:test1", "1", "2");
+        List<String> valuesTest1 = (List<String>) evalScriptGetOffsetCount(":project:server:test:test1", "1", "2");
 
         // ASSERT
         assertThat(valuesTest1.size(), equalTo(3));
@@ -188,7 +186,7 @@ public class RedisGetLuaScriptTests extends AbstractLuaScriptTest {
         assertThat(valuesTest1.get(2), equalTo("test4"));
         
         // ACT
-        List<String> valuesTest2 = (List<String>) evalScriptGet(":project:server:test:test1", "0", "4");
+        List<String> valuesTest2 = (List<String>) evalScriptGetOffsetCount(":project:server:test:test1", "0", "4");
 
         // ASSERT
         assertThat(valuesTest2.size(), equalTo(5));
@@ -199,7 +197,7 @@ public class RedisGetLuaScriptTests extends AbstractLuaScriptTest {
         assertThat(valuesTest2.get(4), equalTo("test5"));
         
         // ACT
-        List<String> valuesTest3 = (List<String>) evalScriptGet(":project:server:test:test1", "0", "-1");
+        List<String> valuesTest3 = (List<String>) evalScriptGetOffsetCount(":project:server:test:test1", "0", "-1");
 
         // ASSERT
         assertThat(valuesTest3.size(), equalTo(5));
@@ -220,7 +218,7 @@ public class RedisGetLuaScriptTests extends AbstractLuaScriptTest {
         evalScriptPut(":project:server:test:test1:test5", "{\"content\": \"test/test1/test5\"}");
 
         // ACT
-        List<String> valuesTest1 = (List<String>) evalScriptGet(":project:server:test:test1", "-1", "2");
+        List<String> valuesTest1 = (List<String>) evalScriptGetOffsetCount(":project:server:test:test1", "-1", "2");
 
         // ASSERT
         assertThat(valuesTest1.size(), equalTo(5));
@@ -231,7 +229,7 @@ public class RedisGetLuaScriptTests extends AbstractLuaScriptTest {
         assertThat(valuesTest1.get(4), equalTo("test5"));
         
         // ACT
-        List<String> valuesTest2 = (List<String>) evalScriptGet(":project:server:test:test1", "0", "9");
+        List<String> valuesTest2 = (List<String>) evalScriptGetOffsetCount(":project:server:test:test1", "0", "9");
 
         // ASSERT
         assertThat(valuesTest2.size(), equalTo(5));
@@ -242,72 +240,10 @@ public class RedisGetLuaScriptTests extends AbstractLuaScriptTest {
         assertThat(valuesTest2.get(4), equalTo("test5"));
         
         // ACT
-        List<String> valuesTest3 = (List<String>) evalScriptGet(":project:server:test:test1", "9", "4");
+        List<String> valuesTest3 = (List<String>) evalScriptGetOffsetCount(":project:server:test:test1", "9", "4");
 
         // ASSERT
         assertThat(valuesTest3.size(), equalTo(1));
         assertThat(valuesTest3.get(0), equalTo(TYPE_COLLECTION));
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private Object evalScriptGet(final String resourceName1) {
-        String getScript = readScript("get.lua");
-        return jedis.eval(getScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add(String.valueOf(System.currentTimeMillis()));
-                add("9999999999999");
-                add("bla");
-                add("bla");
-            }
-        }
-                );
-    }
-    
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private Object evalScriptGet(final String resourceName1, final String offset, final String count) {
-        String getScript = readScript("get.lua");
-        return jedis.eval(getScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add(String.valueOf(System.currentTimeMillis()));
-                add("9999999999999");
-                add(offset);
-                add(count);
-                
-            }
-        }
-                );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private Object evalScriptGet(final String resourceName1, final String timestamp) {
-        String getScript = readScript("get.lua");
-        return jedis.eval(getScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add(timestamp);
-                add("9999999999999");
-            }
-        }
-                );
     }
 }

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisGetLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisGetLuaScriptTests.java
@@ -250,50 +250,6 @@ public class RedisGetLuaScriptTests extends AbstractLuaScriptTest {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private String evalScriptPut(final String resourceName1, final String resourceValue1) {
-        String putScript = readScript("put.lua");
-        return (String) jedis.eval(putScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add("false");
-                add("9999999999999");
-                add("9999999999999");
-                add(resourceValue1);
-                add(UUID.randomUUID().toString());
-            }
-        }
-                );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private void evalScriptPut(final String resourceName1, final String resourceValue1, final String expire) {
-        String putScript = readScript("put.lua");
-        jedis.eval(putScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add("false");
-                add(expire);
-                add("9999999999999");
-                add(resourceValue1);
-                add(UUID.randomUUID().toString());
-            }
-        }
-                );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
     private Object evalScriptGet(final String resourceName1) {
         String getScript = readScript("get.lua");
         return jedis.eval(getScript, new ArrayList() {

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisPutLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisPutLuaScriptTests.java
@@ -64,7 +64,7 @@ public class RedisPutLuaScriptTests extends AbstractLuaScriptTest {
     public void putResourceMergeOnEmpty() {
 
         // ACT
-        String value = (String) evalScriptPutMerge(":project:server:test:test1:test2", "{\"content\": \"test_test1_test3\"}");
+        evalScriptPutMerge(":project:server:test:test1:test2", "{\"content\": \"test_test1_test3\"}");
 
         // ASSERT
         String result = jedis.hget("rest-storage:resources:project:server:test:test1:test2", RESOURCE);
@@ -77,7 +77,7 @@ public class RedisPutLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         evalScriptPut(":project:server:test:test1:test2", "{\"content\": \"test_test1_test2\"}");
-        String value = (String) evalScriptPutMerge(":project:server:test:test1:test2", "{\"content\": \"test_test1_test3\"}");
+        evalScriptPutMerge(":project:server:test:test1:test2", "{\"content\": \"test_test1_test3\"}");
 
         // ASSERT
         String result = jedis.hget("rest-storage:resources:project:server:test:test1:test2", RESOURCE);
@@ -285,44 +285,6 @@ public class RedisPutLuaScriptTests extends AbstractLuaScriptTest {
                         add("9999999999999");
                         add(resourceValue1);
                         add(UUID.randomUUID().toString());
-                    }
-                }
-        );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private Object evalScriptGet(final String resourceName1) {
-        String getScript = readScript("get.lua");
-        return jedis.eval(getScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add(String.valueOf(System.currentTimeMillis()));
-                add("9999999999999");
-            }
-        }
-                );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private Object evalScriptGet(final String resourceName1, final String timestamp) {
-        String getScript = readScript("get.lua");
-        return jedis.eval(getScript, new ArrayList() {
-                    {
-                        add(resourceName1);
-                    }
-                }, new ArrayList() {
-                    {
-                        add(prefixResources);
-                        add(prefixCollections);
-                        add(expirableSet);
-                        add(timestamp);
-                        add("9999999999999");
                     }
                 }
         );

--- a/src/test/java/li/chee/vertx/reststorage/lua/RedisPutLuaScriptTests.java
+++ b/src/test/java/li/chee/vertx/reststorage/lua/RedisPutLuaScriptTests.java
@@ -90,9 +90,9 @@ public class RedisPutLuaScriptTests extends AbstractLuaScriptTest {
 
         // ACT
         String originalContent = "{\"content\": \"originalContent\"}";
-        String value = evalScriptPut(":project:server:test:test1:test2", originalContent, "myFancyEtagValue");
+        String value = evalScriptPut(":project:server:test:test1:test2", originalContent, AbstractLuaScriptTest.MAX_EXPIRE, "myFancyEtagValue");
         String modifiedContent = "{\"content\": \"modifiedContent\"}";
-        String value2 = evalScriptPut(":project:server:test:test1:test2", modifiedContent, "myFancyEtagValue");
+        String value2 = evalScriptPut(":project:server:test:test1:test2", modifiedContent, AbstractLuaScriptTest.MAX_EXPIRE, "myFancyEtagValue");
 
         // ASSERT
         assertThat(value, is(not(equalTo("notModified"))));
@@ -272,40 +272,6 @@ public class RedisPutLuaScriptTests extends AbstractLuaScriptTest {
     private Object evalScriptPutMerge(final String resourceName1, final String resourceValue1) {
         String putScript = readScript("put.lua");
         return jedis.eval(putScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add("true");
-                add("9999999999999");
-                add("9999999999999");
-                add(resourceValue1);
-                add(UUID.randomUUID().toString());
-            }
-        }
-                );
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private String evalScriptPut(final String resourceName1, final String resourceValue1) {
-        return evalScriptPut(resourceName1, resourceValue1, null);
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked", "serial" })
-    private String evalScriptPut(final String resourceName1, final String resourceValue1, final String etag) {
-        String putScript = readScript("put.lua");
-        String etagTmp = null;
-        if(etag != null && !etag.isEmpty()){
-            etagTmp = etag;
-        } else {
-            etagTmp = UUID.randomUUID().toString();
-        }
-        final String etagValue = etagTmp;
-        return (String) jedis.eval(putScript, new ArrayList() {
                     {
                         add(resourceName1);
                     }
@@ -314,11 +280,11 @@ public class RedisPutLuaScriptTests extends AbstractLuaScriptTest {
                         add(prefixResources);
                         add(prefixCollections);
                         add(expirableSet);
-                        add("false");
+                        add("true");
                         add("9999999999999");
                         add("9999999999999");
                         add(resourceValue1);
-                        add(etagValue);
+                        add(UUID.randomUUID().toString());
                     }
                 }
         );
@@ -347,18 +313,18 @@ public class RedisPutLuaScriptTests extends AbstractLuaScriptTest {
     private Object evalScriptGet(final String resourceName1, final String timestamp) {
         String getScript = readScript("get.lua");
         return jedis.eval(getScript, new ArrayList() {
-            {
-                add(resourceName1);
-            }
-        }, new ArrayList() {
-            {
-                add(prefixResources);
-                add(prefixCollections);
-                add(expirableSet);
-                add(timestamp);
-                add("9999999999999");
-            }
-        }
-                );
+                    {
+                        add(resourceName1);
+                    }
+                }, new ArrayList() {
+                    {
+                        add(prefixResources);
+                        add(prefixCollections);
+                        add(expirableSet);
+                        add(timestamp);
+                        add("9999999999999");
+                    }
+                }
+        );
     }
 }


### PR DESCRIPTION
Centralized helper methods like evalScriptPut and evalScriptGet in the AbstractLuaScriptTest class in order to reduce code duplication