### PR TITLE
filesystem().props(...) can fail, e.g. when file is no accessible.

### DIFF
--- a/src/main/java/org/swisspush/reststorage/FileSystemStorage.java
+++ b/src/main/java/org/swisspush/reststorage/FileSystemStorage.java
@@ -51,9 +51,9 @@ public class FileSystemStorage implements Storage {
                             for (final String item : event1.result()) {
                                 fileSystem().props(item, itemProp -> {
                                     Resource r;
-                                    if (itemProp.result().isDirectory()) {
+                                    if (itemProp.succeeded() && itemProp.result().isDirectory()) {
                                         r = new CollectionResource();
-                                    } else if (itemProp.result().isRegularFile()) {
+                                    } else if (itemProp.succeeded() && itemProp.result().isRegularFile()) {
                                         r = new DocumentResource();
                                     } else {
                                         r = new Resource();


### PR DESCRIPTION
Observed on a Windows 10 machine when PUTting of a file is still in progess and another requests queries file list (i.e. directory)

itemProp.result() is null in this case. This leads to a NullPointerException.

This change simply checks for success of the filesystem().props operation and accesses itemProp.result() only on success.