### PR TITLE
Issue 49 option to answer 200 when delete non existing resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,17 +38,17 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-redis-client</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -63,11 +63,11 @@
 
         <!-- TEST dependencies -->
         <dependency>
-            <!--
-                Grrrr. Damn JUnit.jar contains org.hamcrest classes. We need a newer version of Hamcrest in a few tests.
-                Therefore the need to depend on it _before_ JUnit
-            -->
-            <groupId>org.hamcrest</groupId>
+        <!--
+            Grrrr. Damn JUnit.jar contains org.hamcrest classes. We need a newer version of Hamcrest in a few tests.
+            Therefore the need to depend on it _before_ JUnit
+        -->
+        <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>1.3</version>
             <scope>test</scope>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/swisspush/reststorage/RestStorageMod.java
+++ b/src/main/java/org/swisspush/reststorage/RestStorageMod.java
@@ -29,8 +29,7 @@ public class RestStorageMod extends AbstractVerticle {
                 throw new RuntimeException("Storage not supported: " + modConfig.getStorageType());
         }
 
-        Handler<HttpServerRequest> handler = new RestStorageHandler(vertx, log, storage, modConfig.getPrefix(),
-                modConfig.getEditorConfig(), modConfig.isConfirmCollectionDelete(), modConfig.isRejectStorageWriteOnLowMemory());
+        Handler<HttpServerRequest> handler = new RestStorageHandler(vertx, log, storage, modConfig);
 
         // in Vert.x 2x 100-continues was activated per default, in vert.x 3x it is off per default.
         HttpServerOptions options = new HttpServerOptions().setHandle100ContinueAutomatically(true);

--- a/src/main/java/org/swisspush/reststorage/util/ModuleConfiguration.java
+++ b/src/main/java/org/swisspush/reststorage/util/ModuleConfiguration.java
@@ -2,6 +2,8 @@ package org.swisspush.reststorage.util;
 
 import io.vertx.core.json.JsonObject;
 
+import java.util.Map;
+
 /**
  * Utility class to configure the RestStorageModule.
  *
@@ -9,180 +11,137 @@ import io.vertx.core.json.JsonObject;
  */
 public class ModuleConfiguration {
 
-    private String root;
-    private StorageType storageType;
-    private int port;
-    private String prefix;
-    private String storageAddress;
-    private JsonObject editorConfig;
-    private String redisHost;
-    private int redisPort;
-    private String redisAuth;
-    private String expirablePrefix;
-    private String resourcesPrefix;
-    private String collectionsPrefix;
-    private String deltaResourcesPrefix;
-    private String deltaEtagsPrefix;
-    private long resourceCleanupAmount;
-    private String lockPrefix;
-    private boolean confirmCollectionDelete;
-    private boolean rejectStorageWriteOnLowMemory;
-    private long freeMemoryCheckIntervalMs;
-
-    public static final String PROP_ROOT = "root";
-    public static final String PROP_STORAGE_TYPE = "storageType";
-    public static final String PROP_PORT = "port";
-    public static final String PROP_PREFIX = "prefix";
-    public static final String PROP_STORAGE_ADDRESS = "storageAddress";
-    public static final String PROP_EDITOR_CONFIG = "editorConfig";
-    public static final String PROP_REDIS_HOST = "redisHost";
-    public static final String PROP_REDIS_PORT = "redisPort";
-    public static final String PROP_REDIS_AUTH = "redisAuth";
-    public static final String PROP_EXP_PREFIX = "expirablePrefix";
-    public static final String PROP_RES_PREFIX = "resourcesPrefix";
-    public static final String PROP_COL_PREFIX = "collectionsPrefix";
-    public static final String PROP_DELTA_RES_PREFIX = "deltaResourcesPrefix";
-    public static final String PROP_DELTA_ETAGS_PREFIX = "deltaEtagsPrefix";
-    public static final String PROP_RES_CLEANUP_AMMOUNT = "resourceCleanupAmount";
-    public static final String PROP_LOCK_PREFIX = "lockPrefix";
-    public static final String PROP_CONFIRM_COLLECTIONDELETE = "confirmCollectionDelete";
-    public static final String PROP_REJECT_ON_LOW_MEMORY_ENABLED = "rejectStorageWriteOnLowMemory";
-    public static final String PROP_FREE_MEMORY_CHECK_INTERVAL = "freeMemoryCheckIntervalMs";
-
     public enum StorageType {
         filesystem, redis
     }
 
-    /**
-     * Constructor with default values. Use the {@link org.swisspush.reststorage.util.ModuleConfiguration.ModuleConfigurationBuilder} class
-     * for simplyfied custom configuration.
-     */
-    public ModuleConfiguration(){
-        this(new ModuleConfigurationBuilder());
-    }
+    private String             root                          = "."                       ;
+    private StorageType        storageType                   = StorageType.filesystem    ;
+    private int                port                          = 8989                      ;
+    private String             prefix                        = ""                        ;
+    private String             storageAddress                = "resource-storage"        ;
+    private Map<String,String> editorConfig                  = null                      ;
+    private String             redisHost                     = "localhost"               ;
+    private int                redisPort                     = 6379                      ;
+    private String             redisAuth                     = null                      ;
+    private String             expirablePrefix               = "rest-storage:expirable"  ;
+    private String             resourcesPrefix               = "rest-storage:resources"  ;
+    private String             collectionsPrefix             = "rest-storage:collections";
+    private String             deltaResourcesPrefix          = "delta:resources"         ;
+    private String             deltaEtagsPrefix              = "delta:etags"             ;
+    private long               resourceCleanupAmount         = 100_000L                  ;
+    private String             lockPrefix                    = "rest-storage:locks"      ;
+    private boolean            confirmCollectionDelete       = false                     ;
+    private boolean            rejectStorageWriteOnLowMemory = false                     ;
+    private long               freeMemoryCheckIntervalMs     = 60_000L                   ;
+    private boolean            return200onDeleteNonExisting  = false                     ;
 
-    public ModuleConfiguration(String root, StorageType storageType, int port, String prefix, String storageAddress,
-                               JsonObject editorConfig, String redisHost, int redisPort, String redisAuth, String expirablePrefix,
-                               String resourcesPrefix, String collectionsPrefix, String deltaResourcesPrefix,
-                               String deltaEtagsPrefix, long resourceCleanupAmount, String lockPrefix,
-                               boolean confirmCollectionDelete, boolean rejectStorageWriteOnLowMemory, long freeMemoryCheckIntervalMs) {
+    public ModuleConfiguration root(String root) {
         this.root = root;
+        return this;
+    }
+
+    public ModuleConfiguration storageType(StorageType storageType) {
         this.storageType = storageType;
+        return this;
+    }
+
+    public ModuleConfiguration storageTypeFromString(String storageType) throws IllegalArgumentException {
+        this.storageType = StorageType.valueOf(storageType); // let it throw IAEx in case of unknown string value
+        return this;
+    }
+
+    public ModuleConfiguration port(int port) {
         this.port = port;
+        return this;
+    }
+
+    public ModuleConfiguration prefix(String prefix) {
         this.prefix = prefix;
+        return this;
+    }
+
+    public ModuleConfiguration storageAddress(String storageAddress) {
         this.storageAddress = storageAddress;
+        return this;
+    }
+
+    public ModuleConfiguration editorConfig(Map<String,String> editorConfig) {
         this.editorConfig = editorConfig;
+        return this;
+    }
+
+    public ModuleConfiguration redisHost(String redisHost) {
         this.redisHost = redisHost;
+        return this;
+    }
+
+    public ModuleConfiguration redisPort(int redisPort) {
         this.redisPort = redisPort;
+        return this;
+    }
+
+    public ModuleConfiguration redisAuth(String redisAuth) {
         this.redisAuth = redisAuth;
+        return this;
+    }
+
+    public ModuleConfiguration expirablePrefix(String expirablePrefix) {
         this.expirablePrefix = expirablePrefix;
+        return this;
+    }
+
+    public ModuleConfiguration resourcesPrefix(String resourcesPrefix) {
         this.resourcesPrefix = resourcesPrefix;
+        return this;
+    }
+
+    public ModuleConfiguration collectionsPrefix(String collectionsPrefix) {
         this.collectionsPrefix = collectionsPrefix;
+        return this;
+    }
+
+    public ModuleConfiguration deltaResourcesPrefix(String deltaResourcesPrefix) {
         this.deltaResourcesPrefix = deltaResourcesPrefix;
+        return this;
+    }
+
+    public ModuleConfiguration deltaEtagsPrefix(String deltaEtagsPrefix) {
         this.deltaEtagsPrefix = deltaEtagsPrefix;
+        return this;
+    }
+
+    public ModuleConfiguration resourceCleanupAmount(long resourceCleanupAmount) {
         this.resourceCleanupAmount = resourceCleanupAmount;
+        return this;
+    }
+
+    public ModuleConfiguration lockPrefix(String lockPrefix) {
         this.lockPrefix = lockPrefix;
+        return this;
+    }
+
+    public ModuleConfiguration confirmCollectionDelete(boolean confirmCollectionDelete) {
         this.confirmCollectionDelete = confirmCollectionDelete;
+        return this;
+    }
+
+    public ModuleConfiguration rejectStorageWriteOnLowMemory(boolean rejectStorageWriteOnLowMemory) {
         this.rejectStorageWriteOnLowMemory = rejectStorageWriteOnLowMemory;
+        return this;
+    }
+
+    public ModuleConfiguration freeMemoryCheckIntervalMs(long freeMemoryCheckIntervalMs) {
         this.freeMemoryCheckIntervalMs = freeMemoryCheckIntervalMs;
+        return this;
     }
 
-    public static ModuleConfigurationBuilder with(){
-        return new ModuleConfigurationBuilder();
+    public ModuleConfiguration return200onDeleteNonExisting(boolean deleteNonExistingReturn200) {
+        this.return200onDeleteNonExisting = deleteNonExistingReturn200;
+        return this;
     }
 
-    private ModuleConfiguration(ModuleConfigurationBuilder builder){
-        this(builder.root, builder.storageType, builder.port, builder.prefix, builder.storageAddress, builder.editorConfig,
-                builder.redisHost, builder.redisPort, builder.redisAuth, builder.expirablePrefix, builder.resourcesPrefix, builder.collectionsPrefix,
-                builder.deltaResourcesPrefix, builder.deltaEtagsPrefix, builder.resourceCleanupAmount, builder.lockPrefix,
-                builder.confirmCollectionDelete, builder.rejectStorageWriteOnLowMemory, builder.freeMemoryCheckIntervalMs);
-    }
 
-    public JsonObject asJsonObject(){
-        JsonObject obj = new JsonObject();
-        obj.put(PROP_ROOT, getRoot());
-        obj.put(PROP_STORAGE_TYPE, getStorageType().name());
-        obj.put(PROP_PORT, getPort());
-        obj.put(PROP_PREFIX, getPrefix());
-        obj.put(PROP_STORAGE_ADDRESS, getStorageAddress());
-        obj.put(PROP_EDITOR_CONFIG, getEditorConfig());
-        obj.put(PROP_REDIS_HOST, getRedisHost());
-        obj.put(PROP_REDIS_PORT, getRedisPort());
-        obj.put(PROP_REDIS_AUTH, getRedisAuth());
-        obj.put(PROP_EXP_PREFIX, getExpirablePrefix());
-        obj.put(PROP_RES_PREFIX, getResourcesPrefix());
-        obj.put(PROP_COL_PREFIX, getCollectionsPrefix());
-        obj.put(PROP_DELTA_RES_PREFIX, getDeltaResourcesPrefix());
-        obj.put(PROP_DELTA_ETAGS_PREFIX, getDeltaEtagsPrefix());
-        obj.put(PROP_RES_CLEANUP_AMMOUNT, getResourceCleanupAmount());
-        obj.put(PROP_LOCK_PREFIX, getLockPrefix());
-        obj.put(PROP_CONFIRM_COLLECTIONDELETE, isConfirmCollectionDelete());
-        obj.put(PROP_REJECT_ON_LOW_MEMORY_ENABLED, isRejectStorageWriteOnLowMemory());
-        obj.put(PROP_FREE_MEMORY_CHECK_INTERVAL, getFreeMemoryCheckIntervalMs());
-        return obj;
-    }
-
-    public static ModuleConfiguration fromJsonObject(JsonObject json){
-        ModuleConfigurationBuilder builder = ModuleConfiguration.with();
-        if(json.containsKey(PROP_ROOT)){
-            builder.root(json.getString(PROP_ROOT));
-        }
-        if(json.containsKey(PROP_STORAGE_TYPE)){
-            builder.storageTypeFromString(json.getString(PROP_STORAGE_TYPE));
-        }
-        if(json.containsKey(PROP_PORT)){
-            builder.port(json.getInteger(PROP_PORT));
-        }
-        if(json.containsKey(PROP_PREFIX)){
-            builder.prefix(json.getString(PROP_PREFIX));
-        }
-        if(json.containsKey(PROP_STORAGE_ADDRESS)){
-            builder.storageAddress(json.getString(PROP_STORAGE_ADDRESS));
-        }
-        if(json.containsKey(PROP_EDITOR_CONFIG)){
-            builder.editorConfig(json.getJsonObject(PROP_EDITOR_CONFIG));
-        }
-        if(json.containsKey(PROP_REDIS_HOST)){
-            builder.redisHost(json.getString(PROP_REDIS_HOST));
-        }
-        if(json.containsKey(PROP_REDIS_PORT)){
-            builder.redisPort(json.getInteger(PROP_REDIS_PORT));
-        }
-        if(json.containsKey(PROP_REDIS_AUTH)){
-            builder.redisAuth(json.getString(PROP_REDIS_AUTH));
-        }
-        if(json.containsKey(PROP_EXP_PREFIX)){
-            builder.expirablePrefix(json.getString(PROP_EXP_PREFIX));
-        }
-        if(json.containsKey(PROP_RES_PREFIX)){
-            builder.resourcesPrefix(json.getString(PROP_RES_PREFIX));
-        }
-        if(json.containsKey(PROP_COL_PREFIX)){
-            builder.collectionsPrefix(json.getString(PROP_COL_PREFIX));
-        }
-        if(json.containsKey(PROP_DELTA_RES_PREFIX)){
-            builder.deltaResourcesPrefix(json.getString(PROP_DELTA_RES_PREFIX));
-        }
-        if(json.containsKey(PROP_DELTA_ETAGS_PREFIX)){
-            builder.deltaEtagsPrefix(json.getString(PROP_DELTA_ETAGS_PREFIX));
-        }
-        if(json.containsKey(PROP_RES_CLEANUP_AMMOUNT)){
-            builder.resourceCleanupAmount(json.getLong(PROP_RES_CLEANUP_AMMOUNT));
-        }
-        if(json.containsKey(PROP_LOCK_PREFIX)) {
-            builder.lockPrefix(json.getString(PROP_LOCK_PREFIX));
-        }
-        if(json.containsKey(PROP_CONFIRM_COLLECTIONDELETE)){
-            builder.confirmCollectionDelete(json.getBoolean(PROP_CONFIRM_COLLECTIONDELETE));
-        }
-        if(json.containsKey(PROP_REJECT_ON_LOW_MEMORY_ENABLED)){
-            builder.rejectStorageWriteOnLowMemory(json.getBoolean(PROP_REJECT_ON_LOW_MEMORY_ENABLED));
-        }
-        if(json.containsKey(PROP_FREE_MEMORY_CHECK_INTERVAL)){
-            builder.freeMemoryCheckIntervalMs(json.getLong(PROP_FREE_MEMORY_CHECK_INTERVAL));
-        }
-        return builder.build();
-    }
 
     public String getRoot() {
         return root;
@@ -204,7 +163,7 @@ public class ModuleConfiguration {
         return storageAddress;
     }
 
-    public JsonObject getEditorConfig() {
+    public Map<String, String> getEditorConfig() {
         return editorConfig;
     }
 
@@ -252,176 +211,22 @@ public class ModuleConfiguration {
 
     public long getFreeMemoryCheckIntervalMs() { return freeMemoryCheckIntervalMs; }
 
+    public boolean isReturn200onDeleteNonExisting() {
+        return return200onDeleteNonExisting;
+    }
+
+    public JsonObject asJsonObject(){
+        return JsonObject.mapFrom(this);
+    }
+
+    public static ModuleConfiguration fromJsonObject(JsonObject json){
+        ModuleConfiguration mc = json.mapTo(ModuleConfiguration.class);
+        return mc;
+    }
+
     @Override
     public String toString() {
         return asJsonObject().toString();
     }
 
-    /**
-     * ModuleConfigurationBuilder class for simplyfied configuration.
-     *
-     * <pre>Usage:</pre>
-     * <pre>
-     * ModuleConfiguration config = with()
-     *      .redisHost("anotherhost")
-     *      .redisPort(1234)
-     *      .editorConfig(new JsonObject().put("myKey", "myValue"))
-     *      .build();
-     * </pre>
-     */
-    public static class ModuleConfigurationBuilder {
-        private String root;
-        private StorageType storageType;
-        private int port;
-        private String prefix;
-        private String storageAddress;
-        private JsonObject editorConfig;
-        private String redisHost;
-        private int redisPort;
-        private String redisAuth;
-        private String expirablePrefix;
-        private String resourcesPrefix;
-        private String collectionsPrefix;
-        private String deltaResourcesPrefix;
-        private String deltaEtagsPrefix;
-        private long resourceCleanupAmount;
-        private String lockPrefix;
-        private boolean confirmCollectionDelete;
-        private boolean rejectStorageWriteOnLowMemory;
-        private long freeMemoryCheckIntervalMs;
-
-        private static final long DEFAULT_FREE_MEMORY_CHECK_INTERVAL = 60000; // 60s
-
-        public ModuleConfigurationBuilder(){
-            this.root = ".";
-            this.storageType = StorageType.filesystem;
-            this.port = 8989;
-            this.prefix = "";
-            this.storageAddress = "resource-storage";
-            this.editorConfig = null;
-            this.redisHost = "localhost";
-            this.redisPort = 6379;
-            this.expirablePrefix = "rest-storage:expirable";
-            this.resourcesPrefix = "rest-storage:resources";
-            this.collectionsPrefix = "rest-storage:collections";
-            this.deltaResourcesPrefix = "delta:resources";
-            this.deltaEtagsPrefix = "delta:etags";
-            this.resourceCleanupAmount = 100000L;
-            this.lockPrefix = "rest-storage:locks";
-            this.confirmCollectionDelete = false;
-            this.rejectStorageWriteOnLowMemory = false;
-            this.freeMemoryCheckIntervalMs = DEFAULT_FREE_MEMORY_CHECK_INTERVAL;
-        }
-
-        public ModuleConfigurationBuilder root(String root){
-            this.root = root;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder storageType(StorageType storageType){
-            this.storageType = storageType;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder storageTypeFromString(String storageType){
-            for(StorageType type : StorageType.values()){
-                if (type.name().equalsIgnoreCase(storageType)){
-                    this.storageType = type;
-                }
-            }
-            if(this.storageType == null) {
-                this.storageType = StorageType.filesystem;
-            }
-            return this;
-        }
-
-        public ModuleConfigurationBuilder port(int port){
-            this.port = port;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder prefix(String prefix){
-            this.prefix = prefix;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder storageAddress(String storageAddress){
-            this.storageAddress = storageAddress;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder editorConfig(JsonObject editorConfig){
-            this.editorConfig = editorConfig;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder redisHost(String redisHost){
-            this.redisHost = redisHost;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder redisPort(int redisPort){
-            this.redisPort = redisPort;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder redisAuth(String redisAuth){
-            this.redisAuth = redisAuth;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder expirablePrefix(String expirablePrefix){
-            this.expirablePrefix = expirablePrefix;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder resourcesPrefix(String resourcesPrefix){
-            this.resourcesPrefix = resourcesPrefix;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder collectionsPrefix(String collectionsPrefix){
-            this.collectionsPrefix = collectionsPrefix;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder deltaResourcesPrefix(String deltaResourcesPrefix){
-            this.deltaResourcesPrefix = deltaResourcesPrefix;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder deltaEtagsPrefix(String deltaEtagsPrefix){
-            this.deltaEtagsPrefix = deltaEtagsPrefix;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder resourceCleanupAmount(long resourceCleanupAmount){
-            this.resourceCleanupAmount = resourceCleanupAmount;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder lockPrefix(String lockPrefix) {
-            this.lockPrefix = lockPrefix;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder confirmCollectionDelete(boolean confirmCollectionDelete){
-            this.confirmCollectionDelete = confirmCollectionDelete;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder rejectStorageWriteOnLowMemory(boolean rejectStorageWriteOnLowMemory){
-            this.rejectStorageWriteOnLowMemory = rejectStorageWriteOnLowMemory;
-            return this;
-        }
-
-        public ModuleConfigurationBuilder freeMemoryCheckIntervalMs(long freeMemoryCheckIntervalMs) {
-            this.freeMemoryCheckIntervalMs = freeMemoryCheckIntervalMs;
-            return this;
-        }
-
-        public ModuleConfiguration build(){
-            return new ModuleConfiguration(this);
-        }
-    }
 }

--- a/src/test/java/org/swisspush/reststorage/FilesystemStorageTestCase.java
+++ b/src/test/java/org/swisspush/reststorage/FilesystemStorageTestCase.java
@@ -26,11 +26,10 @@ public abstract class FilesystemStorageTestCase extends ConfigurableTestCase {
         RestAssured.registerParser("application/json; charset=utf-8", Parser.JSON);
         RestAssured.defaultParser = Parser.JSON;
 
-        ModuleConfiguration modConfig = ModuleConfiguration.with()
+        ModuleConfiguration modConfig = new ModuleConfiguration()
                 .storageType(ModuleConfiguration.StorageType.filesystem)
                 .confirmCollectionDelete(true)
-                .storageAddress("rest-storage")
-                .build();
+                .storageAddress("rest-storage");
 
         RestStorageMod restStorageMod = new RestStorageMod();
         vertx.deployVerticle(restStorageMod, new DeploymentOptions().setConfig(modConfig.asJsonObject()), context.asyncAssertSuccess(stringAsyncResult1 -> {

--- a/src/test/java/org/swisspush/reststorage/RedisStorageIntegrationTestCase.java
+++ b/src/test/java/org/swisspush/reststorage/RedisStorageIntegrationTestCase.java
@@ -28,11 +28,10 @@ public abstract class RedisStorageIntegrationTestCase extends ConfigurableTestCa
         RestAssured.registerParser("application/json; charset=utf-8", Parser.JSON);
         RestAssured.defaultParser = Parser.JSON;
 
-        ModuleConfiguration modConfig = ModuleConfiguration.with()
+        ModuleConfiguration modConfig = new ModuleConfiguration()
                 .storageType(ModuleConfiguration.StorageType.redis)
                 .confirmCollectionDelete(true)
-                .storageAddress("rest-storage")
-                .build();
+                .storageAddress("rest-storage");
 
         RestStorageMod restStorageMod = new RestStorageMod();
         vertx.deployVerticle(restStorageMod, new DeploymentOptions().setConfig(modConfig.asJsonObject()), context.asyncAssertSuccess(stringAsyncResult1 -> {

--- a/src/test/java/org/swisspush/reststorage/RedisStorageIntegrationTestCase.java
+++ b/src/test/java/org/swisspush/reststorage/RedisStorageIntegrationTestCase.java
@@ -33,11 +33,19 @@ public abstract class RedisStorageIntegrationTestCase extends ConfigurableTestCa
                 .confirmCollectionDelete(true)
                 .storageAddress("rest-storage");
 
+        updateModuleConfiguration(modConfig);
+
         RestStorageMod restStorageMod = new RestStorageMod();
         vertx.deployVerticle(restStorageMod, new DeploymentOptions().setConfig(modConfig.asJsonObject()), context.asyncAssertSuccess(stringAsyncResult1 -> {
             // standard code: will called @Before every test
             RestAssured.basePath = "";
         }));
+    }
+
+    /**
+     * chance for specific unit test classes to change config here
+     */
+    protected void updateModuleConfiguration(ModuleConfiguration modConfig) {
     }
 
     @After

--- a/src/test/java/org/swisspush/reststorage/RestStorageHandlerTest.java
+++ b/src/test/java/org/swisspush/reststorage/RestStorageHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.swisspush.reststorage.util.HttpRequestHeader;
+import org.swisspush.reststorage.util.ModuleConfiguration;
 import org.swisspush.reststorage.util.StatusCode;
 
 import java.util.Optional;
@@ -58,8 +59,8 @@ public class RestStorageHandlerTest {
 
     @Test
     public void testPUTWithInvalidImportanceLevelHeader(TestContext testContext) {
-        restStorageHandler = new RestStorageHandler(vertx, log, storage, "/", null,
-                false, true);
+        ModuleConfiguration config = new ModuleConfiguration().prefix("/").rejectStorageWriteOnLowMemory(true);
+        restStorageHandler = new RestStorageHandler(vertx, log, storage, config);
 
         // ARRANGE
         when(request.headers()).thenReturn(new CaseInsensitiveHeaders().add(HttpRequestHeader.IMPORTANCE_LEVEL_HEADER.getName(), "not_a_number"));
@@ -77,8 +78,8 @@ public class RestStorageHandlerTest {
 
     @Test
     public void testPUTWithEnabledRejectStorageWriteOnLowMemoryButNoHeaders(TestContext testContext) {
-        restStorageHandler = new RestStorageHandler(vertx, log, storage, "/", null,
-                false, true);
+        ModuleConfiguration config = new ModuleConfiguration().prefix("/").rejectStorageWriteOnLowMemory(true);
+        restStorageHandler = new RestStorageHandler(vertx, log, storage, config);
 
         // ACT
         restStorageHandler.handle(request);
@@ -91,8 +92,8 @@ public class RestStorageHandlerTest {
 
     @Test
     public void testPUTWithDisabledRejectStorageWriteOnLowMemoryButHeaders(TestContext testContext) {
-        restStorageHandler = new RestStorageHandler(vertx, log, storage, "/", null,
-                false, false);
+        ModuleConfiguration config = new ModuleConfiguration().prefix("/").rejectStorageWriteOnLowMemory(false);
+        restStorageHandler = new RestStorageHandler(vertx, log, storage, config);
 
         // ARRANGE
         when(request.headers()).thenReturn(new CaseInsensitiveHeaders().add(HttpRequestHeader.IMPORTANCE_LEVEL_HEADER.getName(), "50"));
@@ -108,8 +109,8 @@ public class RestStorageHandlerTest {
 
     @Test
     public void testPUTWithNoMemoryUsageAvailable(TestContext testContext) {
-        restStorageHandler = new RestStorageHandler(vertx, log, storage, "/", null,
-                false, true);
+        ModuleConfiguration config = new ModuleConfiguration().prefix("/").rejectStorageWriteOnLowMemory(true);
+        restStorageHandler = new RestStorageHandler(vertx, log, storage, config);
 
         // ARRANGE
         when(request.headers()).thenReturn(new CaseInsensitiveHeaders().add(HttpRequestHeader.IMPORTANCE_LEVEL_HEADER.getName(), "50"));
@@ -125,8 +126,8 @@ public class RestStorageHandlerTest {
 
     @Test
     public void testRejectPUTRequestWhenMemoryUsageHigherThanImportanceLevel(TestContext testContext) {
-        restStorageHandler = new RestStorageHandler(vertx, log, storage, "/", null,
-                false, true);
+        ModuleConfiguration config = new ModuleConfiguration().prefix("/").rejectStorageWriteOnLowMemory(true);
+        restStorageHandler = new RestStorageHandler(vertx, log, storage, config);
 
         // ARRANGE
         when(request.headers()).thenReturn(new CaseInsensitiveHeaders().add(HttpRequestHeader.IMPORTANCE_LEVEL_HEADER.getName(), "50"));

--- a/src/test/java/org/swisspush/reststorage/Return200onDeleteNonExistingTest.java
+++ b/src/test/java/org/swisspush/reststorage/Return200onDeleteNonExistingTest.java
@@ -1,0 +1,19 @@
+package org.swisspush.reststorage;
+
+import org.junit.Test;
+import org.swisspush.reststorage.util.ModuleConfiguration;
+
+import static com.jayway.restassured.RestAssured.when;
+
+public class Return200onDeleteNonExistingTest extends RedisStorageIntegrationTestCase {
+
+    @Override
+    protected void updateModuleConfiguration(ModuleConfiguration modConfig) {
+        modConfig.return200onDeleteNonExisting(true);
+    }
+
+    @Test
+    public void expect200() {
+        when().delete("resources/does-not-exist").then().assertThat().statusCode(200);
+    }
+}

--- a/src/test/java/org/swisspush/reststorage/Return404onDeleteNonExistingTest.java
+++ b/src/test/java/org/swisspush/reststorage/Return404onDeleteNonExistingTest.java
@@ -1,0 +1,14 @@
+package org.swisspush.reststorage;
+
+import org.junit.Test;
+
+import static com.jayway.restassured.RestAssured.when;
+
+public class Return404onDeleteNonExistingTest extends RedisStorageIntegrationTestCase {
+
+    @Test
+    public void expect404() {
+        // default config response with 404 if we delete a non-existing resource
+        when().delete("resources/does-not-exist").then().assertThat().statusCode(404);
+    }
+}

--- a/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
+++ b/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
@@ -6,7 +6,10 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.swisspush.reststorage.util.ModuleConfiguration.*;
+import java.util.HashMap;
+
+import static org.swisspush.reststorage.util.ModuleConfiguration.StorageType;
+import static org.swisspush.reststorage.util.ModuleConfiguration.fromJsonObject;
 
 /**
  * Tests for {@link ModuleConfiguration} class.
@@ -19,6 +22,11 @@ public class ModuleConfigurationTest {
     @Test
     public void testDefaultConfiguration(TestContext testContext) {
         ModuleConfiguration config = new ModuleConfiguration();
+
+        // go through JSON encode/decode
+        String json = config.asJsonObject().encodePrettily();
+        config = ModuleConfiguration.fromJsonObject(new JsonObject(json));
+
         testContext.assertEquals(config.getRoot(), ".");
         testContext.assertEquals(config.getStorageType(), StorageType.filesystem);
         testContext.assertEquals(config.getPort(), 8989);
@@ -37,18 +45,25 @@ public class ModuleConfigurationTest {
         testContext.assertFalse(config.isConfirmCollectionDelete());
         testContext.assertFalse(config.isRejectStorageWriteOnLowMemory());
         testContext.assertEquals(config.getFreeMemoryCheckIntervalMs(), 60000L);
+        testContext.assertFalse(config.isReturn200onDeleteNonExisting());
     }
 
     @Test
-    public void testOverrideConfiguration(TestContext testContext){
-        ModuleConfiguration config = with()
+    public void testOverrideConfiguration(TestContext testContext) {
+        ModuleConfiguration config = new ModuleConfiguration()
                 .redisHost("anotherhost")
                 .redisPort(1234)
-                .editorConfig(new JsonObject().put("myKey", "myValue"))
+                .editorConfig(new HashMap<String, String>() {{
+                    put("myKey", "myValue");
+                }})
                 .confirmCollectionDelete(true)
                 .rejectStorageWriteOnLowMemory(true)
                 .freeMemoryCheckIntervalMs(10000)
-                .build();
+                .return200onDeleteNonExisting(true);
+
+        // go through JSON encode/decode
+        String json = config.asJsonObject().encodePrettily();
+        config = ModuleConfiguration.fromJsonObject(new JsonObject(json));
 
         // default values
         testContext.assertEquals(config.getRoot(), ".");
@@ -64,16 +79,16 @@ public class ModuleConfigurationTest {
         testContext.assertEquals(config.getResourceCleanupAmount(), 100000L);
         testContext.assertEquals(config.getLockPrefix(), "rest-storage:locks");
 
-
             // overriden values
         testContext.assertEquals(config.getRedisHost(), "anotherhost");
         testContext.assertEquals(config.getRedisPort(), 1234);
         testContext.assertNotNull(config.getEditorConfig());
         testContext.assertTrue(config.getEditorConfig().containsKey("myKey"));
-        testContext.assertEquals(config.getEditorConfig().getString("myKey"), "myValue");
+        testContext.assertEquals(config.getEditorConfig().get("myKey"), "myValue");
         testContext.assertTrue(config.isConfirmCollectionDelete());
         testContext.assertTrue(config.isRejectStorageWriteOnLowMemory());
         testContext.assertEquals(config.getFreeMemoryCheckIntervalMs(), 10000L);
+        testContext.assertTrue(config.isReturn200onDeleteNonExisting());
     }
 
     @Test
@@ -81,65 +96,67 @@ public class ModuleConfigurationTest {
         ModuleConfiguration config = new ModuleConfiguration();
         JsonObject json = config.asJsonObject();
 
-        testContext.assertEquals(json.getString(PROP_ROOT), ".");
-        testContext.assertEquals(json.getString(PROP_STORAGE_TYPE), StorageType.filesystem.name());
-        testContext.assertEquals(json.getInteger(PROP_PORT), 8989);
-        testContext.assertEquals(json.getString(PROP_PREFIX), "");
-        testContext.assertEquals(json.getString(PROP_STORAGE_ADDRESS), "resource-storage");
-        testContext.assertNull(json.getJsonObject(PROP_EDITOR_CONFIG));
-        testContext.assertEquals(json.getString(PROP_REDIS_HOST), "localhost");
-        testContext.assertEquals(json.getInteger(PROP_REDIS_PORT), 6379);
-        testContext.assertEquals(json.getString(PROP_EXP_PREFIX), "rest-storage:expirable");
-        testContext.assertEquals(json.getString(PROP_RES_PREFIX), "rest-storage:resources");
-        testContext.assertEquals(json.getString(PROP_COL_PREFIX), "rest-storage:collections");
-        testContext.assertEquals(json.getString(PROP_DELTA_RES_PREFIX), "delta:resources");
-        testContext.assertEquals(json.getString(PROP_DELTA_ETAGS_PREFIX), "delta:etags");
-        testContext.assertEquals(json.getLong(PROP_RES_CLEANUP_AMMOUNT), 100000L);
-        testContext.assertEquals(json.getString(PROP_LOCK_PREFIX), "rest-storage:locks");
-        testContext.assertFalse(json.getBoolean(PROP_CONFIRM_COLLECTIONDELETE));
-        testContext.assertFalse(json.getBoolean(PROP_REJECT_ON_LOW_MEMORY_ENABLED));
-        testContext.assertEquals(json.getLong(PROP_FREE_MEMORY_CHECK_INTERVAL), 60000L);
+        testContext.assertEquals(json.getString("root"), ".");
+        testContext.assertEquals(json.getString("storageType"), StorageType.filesystem.name());
+        testContext.assertEquals(json.getInteger("port"), 8989);
+        testContext.assertEquals(json.getString("prefix"), "");
+        testContext.assertEquals(json.getString("storageAddress"), "resource-storage");
+        testContext.assertNull(json.getJsonObject("editorConfig"));
+        testContext.assertEquals(json.getString("redisHost"), "localhost");
+        testContext.assertEquals(json.getInteger("redisPort"), 6379);
+        testContext.assertNull(json.getString("redisAuth"));
+        testContext.assertEquals(json.getString("expirablePrefix"), "rest-storage:expirable");
+        testContext.assertEquals(json.getString("resourcesPrefix"), "rest-storage:resources");
+        testContext.assertEquals(json.getString("collectionsPrefix"), "rest-storage:collections");
+        testContext.assertEquals(json.getString("deltaResourcesPrefix"), "delta:resources");
+        testContext.assertEquals(json.getString("deltaEtagsPrefix"), "delta:etags");
+        testContext.assertEquals(json.getLong("resourceCleanupAmount"), 100000L);
+        testContext.assertEquals(json.getString("lockPrefix"), "rest-storage:locks");
+        testContext.assertFalse(json.getBoolean("confirmCollectionDelete"));
+        testContext.assertFalse(json.getBoolean("rejectStorageWriteOnLowMemory"));
+        testContext.assertEquals(json.getLong("freeMemoryCheckIntervalMs"), 60000L);
     }
 
     @Test
     public void testGetOverridenAsJsonObject(TestContext testContext){
 
-        ModuleConfiguration config = with()
+        ModuleConfiguration config = new ModuleConfiguration()
                 .redisHost("anotherhost")
                 .redisPort(1234)
-                .editorConfig(new JsonObject().put("myKey", "myValue"))
+                .editorConfig(new HashMap<String, String>() {{
+                    put("myKey", "myValue");
+                }})
                 .confirmCollectionDelete(true)
                 .rejectStorageWriteOnLowMemory(true)
-                .freeMemoryCheckIntervalMs(5000)
-                .build();
+                .freeMemoryCheckIntervalMs(5000);
 
         JsonObject json = config.asJsonObject();
 
         // default values
-        testContext.assertEquals(json.getString(PROP_ROOT), ".");
-        testContext.assertEquals(json.getString(PROP_STORAGE_TYPE), StorageType.filesystem.name());
-        testContext.assertEquals(json.getInteger(PROP_PORT), 8989);
-        testContext.assertEquals(json.getString(PROP_PREFIX), "");
-        testContext.assertEquals(json.getString(PROP_STORAGE_ADDRESS), "resource-storage");
-        testContext.assertEquals(json.getString(PROP_EXP_PREFIX), "rest-storage:expirable");
-        testContext.assertEquals(json.getString(PROP_RES_PREFIX), "rest-storage:resources");
-        testContext.assertEquals(json.getString(PROP_COL_PREFIX), "rest-storage:collections");
-        testContext.assertEquals(json.getString(PROP_DELTA_RES_PREFIX), "delta:resources");
-        testContext.assertEquals(json.getString(PROP_DELTA_ETAGS_PREFIX), "delta:etags");
-        testContext.assertEquals(json.getLong(PROP_RES_CLEANUP_AMMOUNT), 100000L);
-        testContext.assertEquals(json.getString(PROP_LOCK_PREFIX), "rest-storage:locks");
+        testContext.assertEquals(json.getString("root"), ".");
+        testContext.assertEquals(json.getString("storageType"), StorageType.filesystem.name());
+        testContext.assertEquals(json.getInteger("port"), 8989);
+        testContext.assertEquals(json.getString("prefix"), "");
+        testContext.assertEquals(json.getString("storageAddress"), "resource-storage");
+        testContext.assertEquals(json.getString("expirablePrefix"), "rest-storage:expirable");
+        testContext.assertEquals(json.getString("resourcesPrefix"), "rest-storage:resources");
+        testContext.assertEquals(json.getString("collectionsPrefix"), "rest-storage:collections");
+        testContext.assertEquals(json.getString("deltaResourcesPrefix"), "delta:resources");
+        testContext.assertEquals(json.getString("deltaEtagsPrefix"), "delta:etags");
+        testContext.assertEquals(json.getLong("resourceCleanupAmount"), 100000L);
+        testContext.assertEquals(json.getString("lockPrefix"), "rest-storage:locks");
 
 
         // overriden values
-        testContext.assertEquals(json.getString(PROP_REDIS_HOST), "anotherhost");
-        testContext.assertEquals(json.getInteger(PROP_REDIS_PORT), 1234);
-        testContext.assertTrue(json.getBoolean(PROP_CONFIRM_COLLECTIONDELETE));
-        testContext.assertTrue(json.getBoolean(PROP_REJECT_ON_LOW_MEMORY_ENABLED));
+        testContext.assertEquals(json.getString("redisHost"), "anotherhost");
+        testContext.assertEquals(json.getInteger("redisPort"), 1234);
+        testContext.assertTrue(json.getBoolean("confirmCollectionDelete"));
+        testContext.assertTrue(json.getBoolean("rejectStorageWriteOnLowMemory"));
         testContext.assertEquals(config.getFreeMemoryCheckIntervalMs(), 5000L);
 
-        testContext.assertNotNull(json.getJsonObject(PROP_EDITOR_CONFIG));
-        testContext.assertTrue(json.getJsonObject(PROP_EDITOR_CONFIG).containsKey("myKey"));
-        testContext.assertEquals(json.getJsonObject(PROP_EDITOR_CONFIG).getString("myKey"), "myValue");
+        testContext.assertNotNull(json.getJsonObject("editorConfig"));
+        testContext.assertTrue(json.getJsonObject("editorConfig").containsKey("myKey"));
+        testContext.assertEquals(json.getJsonObject("editorConfig").getString("myKey"), "myValue");
     }
 
     @Test
@@ -171,24 +188,24 @@ public class ModuleConfigurationTest {
     public void testGetOverridenFromJsonObject(TestContext testContext){
 
         JsonObject json = new JsonObject();
-        json.put(PROP_ROOT, "newroot");
-        json.put(PROP_STORAGE_TYPE, "redis");
-        json.put(PROP_PORT, 1234);
-        json.put(PROP_PREFIX, "newprefix");
-        json.put(PROP_STORAGE_ADDRESS, "newStorageAddress");
-        json.put(PROP_EDITOR_CONFIG, new JsonObject().put("myKey", "myValue"));
-        json.put(PROP_REDIS_HOST, "newredishost");
-        json.put(PROP_REDIS_PORT, 4321);
-        json.put(PROP_EXP_PREFIX, "newExpirablePrefix");
-        json.put(PROP_RES_PREFIX, "newResourcesPrefix");
-        json.put(PROP_COL_PREFIX, "newCollectionsPrefix");
-        json.put(PROP_DELTA_RES_PREFIX, "newDeltaResourcesPrefix");
-        json.put(PROP_DELTA_ETAGS_PREFIX, "newDeltaEtagsPrefix");
-        json.put(PROP_RES_CLEANUP_AMMOUNT, 999L);
-        json.put(PROP_LOCK_PREFIX, "newLockPrefix");
-        json.put(PROP_CONFIRM_COLLECTIONDELETE, true);
-        json.put(PROP_REJECT_ON_LOW_MEMORY_ENABLED, true);
-        json.put(PROP_FREE_MEMORY_CHECK_INTERVAL, 30000);
+        json.put("root", "newroot");
+        json.put("storageType", "redis");
+        json.put("port", 1234);
+        json.put("prefix", "newprefix");
+        json.put("storageAddress", "newStorageAddress");
+        json.put("editorConfig", new JsonObject().put("myKey", "myValue"));
+        json.put("redisHost", "newredishost");
+        json.put("redisPort", 4321);
+        json.put("expirablePrefix", "newExpirablePrefix");
+        json.put("resourcesPrefix", "newResourcesPrefix");
+        json.put("collectionsPrefix", "newCollectionsPrefix");
+        json.put("deltaResourcesPrefix", "newDeltaResourcesPrefix");
+        json.put("deltaEtagsPrefix", "newDeltaEtagsPrefix");
+        json.put("resourceCleanupAmount", 999L);
+        json.put("lockPrefix", "newLockPrefix");
+        json.put("confirmCollectionDelete", true);
+        json.put("rejectStorageWriteOnLowMemory", true);
+        json.put("freeMemoryCheckIntervalMs", 30000);
 
         ModuleConfiguration config = fromJsonObject(json);
         testContext.assertEquals(config.getRoot(), "newroot");
@@ -199,7 +216,7 @@ public class ModuleConfigurationTest {
 
         testContext.assertNotNull(config.getEditorConfig());
         testContext.assertTrue(config.getEditorConfig().containsKey("myKey"));
-        testContext.assertEquals(config.getEditorConfig().getString("myKey"), "myValue");
+        testContext.assertEquals(config.getEditorConfig().get("myKey"), "myValue");
 
         testContext.assertEquals(config.getRedisHost(), "newredishost");
         testContext.assertEquals(config.getRedisPort(), 4321);


### PR DESCRIPTION
Solves #49 

additonally
- simplified ModuleConfiguration. Make use of new Vertx's JsonObject features "mapTo()" and "mapFrom()". No need for class ModuleConfigurationBuilder any more and no need for manual mapping to/from JSON. 
Note that this is a breaking change - but adaption (e.g. in Gateleen) is easy and straight forward.
- update to Vertx 3.5.1