### PR TITLE
[#57] Delete empty parents when deleting last file

### DIFF
--- a/src/test/java/org/swisspush/reststorage/FilesystemStorageTestCase.java
+++ b/src/test/java/org/swisspush/reststorage/FilesystemStorageTestCase.java
@@ -4,6 +4,7 @@ import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.parsing.Parser;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
+import io.vertx.core.file.FileSystem;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
@@ -40,6 +41,9 @@ public abstract class FilesystemStorageTestCase extends ConfigurableTestCase {
 
     @After
     public void deleteTestFiles(TestContext context){
-        vertx.fileSystem().deleteRecursiveBlocking(TEST_FILES_PATH, true);
+        final FileSystem fileSystem = vertx.fileSystem();
+        if( fileSystem.existsBlocking(TEST_FILES_PATH) ){
+            fileSystem.deleteRecursiveBlocking(TEST_FILES_PATH, true);
+        }
     }
 }


### PR DESCRIPTION
After deleting a file (aka resource in FileSystemStorage) we now bubble
up and delete empty directories.