### PR TITLE
[#69] Re-implement directory listing for file storage

### DIFF
--- a/src/main/java/org/swisspush/reststorage/FileSystemDirLister.java
+++ b/src/main/java/org/swisspush/reststorage/FileSystemDirLister.java
@@ -19,49 +19,49 @@ import java.util.stream.Stream;
 /**
  * This type handles listing of directories in filesystem.
  *
- * Internally it makes use of worker-threads to keep eventloop-thread
- * responsive.
+ * <p>Internally it makes use of worker-threads to keep eventloop-thread
+ * responsive.</p>
  */
 public class FileSystemDirLister {
 
-    private static final Logger log = LoggerFactory.getLogger( FileSystemDirLister.class );
+    private static final Logger log = LoggerFactory.getLogger(FileSystemDirLister.class);
     private final Vertx vertx;
     private final String root;
 
-    public FileSystemDirLister(Vertx vertx, String root){
+    public FileSystemDirLister(Vertx vertx, String root) {
         this.vertx = vertx;
         this.root = root;
     }
 
     public void handleListingRequest(String path, final int offset, final int count, final Handler<Resource> handler) {
         // Delegate work to worker thread from thread pool.
-        log.trace( "Delegate to worker pool" );
+        log.trace("Delegate to worker pool");
         final long startTimeMillis = System.currentTimeMillis();
-        vertx.executeBlocking( future -> {
-            log.trace( "Welcome on worker-thread." );
-            listDirBlocking( path, offset , count , (Future<CollectionResource>)(Future<?>)future );
-            log.trace( "worker-thread says bye." );
+        vertx.executeBlocking(future -> {
+            log.trace("Welcome on worker-thread.");
+            listDirBlocking(path, offset, count, (Future<CollectionResource>) (Future<?>) future);
+            log.trace("worker-thread says bye.");
         }, event -> {
-            log.trace( "Welcome back on eventloop-thread." );
-            if( log.isDebugEnabled() ){
+            log.trace("Welcome back on eventloop-thread.");
+            if (log.isDebugEnabled()) {
                 final long durationMillis = System.currentTimeMillis() - startTimeMillis;
-                log.debug( "List directory contents of '{}' took {}ms", path, durationMillis );
+                log.debug("List directory contents of '{}' took {}ms", path, durationMillis);
             }
-            if( event.failed() ){
-                log.error( "Directory listing failed." , event.cause() );
-                final Resource erroneousResource = new Resource(){{
+            if (event.failed()) {
+                log.error("Directory listing failed.", event.cause());
+                final Resource erroneousResource = new Resource() {{
                     // Set fields according to documentation in Resource class.
                     name = Paths.get(path).getFileName().toString();
                     exists = false;
                     error = rejected = invalid = true;
                     errorMessage = invalidMessage = event.cause().getMessage();
                 }};
-                handler.handle( erroneousResource );
-            }else{
-                handler.handle( (Resource)event.result() );
+                handler.handle(erroneousResource);
+            } else {
+                handler.handle((Resource) event.result());
             }
         });
-        log.trace( "Work delegated." );
+        log.trace("Work delegated.");
     }
 
     private void listDirBlocking(String path, int offset, int count, Future<CollectionResource> future) {
@@ -71,54 +71,54 @@ public class FileSystemDirLister {
         // Convert String to Path
         final Path searchPath = Paths.get(canonicalizeVirtualPath(path));
         // Prepare our result.
-        final CollectionResource collection = new CollectionResource(){{
-            items = new ArrayList<>( 128 );
+        final CollectionResource collection = new CollectionResource() {{
+            items = new ArrayList<>(128);
         }};
         final String fullPath = canonicalizeVirtualPath(path);
-        try(Stream<Path> source = Files.list(searchPath) ){
+        try (Stream<Path> source = Files.list(searchPath)) {
             source.forEach(entry -> {
                 final String entryName = entry.getFileName().toString();
-                log.trace( "Processing entry '{}'", entryName );
-                if( ".tmp".equals(entryName) && fullPath.length()==root.length() ){
+                log.trace("Processing entry '{}'", entryName);
+                if (".tmp".equals(entryName) && fullPath.length() == root.length()) {
                     // Ignore hidden '/.tmp/' directory.
                     return;
                 }
                 // Create resource representing currently processed directory entry.
                 final Resource resource;
-                if( Files.isDirectory(entry) ){
+                if (Files.isDirectory(entry)) {
                     resource = new CollectionResource();
-                }else if( Files.isRegularFile(entry) ){
+                } else if (Files.isRegularFile(entry)) {
                     resource = new DocumentResource();
-                }else{
+                } else {
                     resource = new Resource();
                     resource.exists = false;
                 }
                 resource.name = entryName;
-                collection.items.add( resource );
+                collection.items.add(resource);
             });
-        }catch( IOException e ){
-            future.fail( e );
+        } catch (IOException e) {
+            future.fail(e);
             return;
         }
-        Collections.sort( collection.items );
+        Collections.sort(collection.items);
         // Don't know exactly what we do here now. Seems we check 'limit' for a range request.
         int n = count;
-        if(n == -1) {
+        if (n == -1) {
             n = collection.items.size();
         }
         // Don't know exactly what we do here. But it seems we evaluate 'start' of a range request.
-        if(offset > -1) {
-            if(offset >= collection.items.size() || (offset+n) >= collection.items.size() || (offset == 0 && n == -1)) {
-                future.complete( collection );
+        if (offset > -1) {
+            if (offset >= collection.items.size() || (offset + n) >= collection.items.size() || (offset == 0 && n == -1)) {
+                future.complete(collection);
             } else {
-                collection.items = collection.items.subList(offset, offset+n);
-                future.complete( collection );
+                collection.items = collection.items.subList(offset, offset + n);
+                future.complete(collection);
             }
-        }else{
+        } else {
             // TODO: Resolve future
             //       Previous implementation did nothing here. Why? Should we do something here?
             //       See: "https://github.com/hiddenalpha/vertx-rest-storage/blob/v2.5.2/src/main/java/org/swisspush/reststorage/FileSystemStorage.java#L77"
-            log.warn( "May we should do something here. I've no idea why old implementation did nothing." );
+            log.warn("May we should do something here. I've no idea why old implementation did nothing.");
         }
     }
 

--- a/src/main/java/org/swisspush/reststorage/FileSystemDirLister.java
+++ b/src/main/java/org/swisspush/reststorage/FileSystemDirLister.java
@@ -1,0 +1,137 @@
+package org.swisspush.reststorage;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+
+/**
+ * This type handles listing of directories in filesystem.
+ *
+ * Internally it makes use of worker-threads to keep eventloop-thread
+ * responsive.
+ */
+public class FileSystemDirLister {
+
+    private static final Logger log = LoggerFactory.getLogger( FileSystemDirLister.class );
+    private final Vertx vertx;
+    private final String root;
+
+    public FileSystemDirLister(Vertx vertx, String root){
+        this.vertx = vertx;
+        this.root = root;
+    }
+
+    public void handleListingRequest(String path, final int offset, final int count, final Handler<Resource> handler) {
+        // Delegate work to worker thread from thread pool.
+        log.trace( "Delegate to worker pool" );
+        final long startTimeMillis = System.currentTimeMillis();
+        vertx.executeBlocking( future -> {
+            log.trace( "Welcome on worker-thread." );
+            listDirBlocking( path, offset , count , (Future<CollectionResource>)(Future<?>)future );
+            log.trace( "worker-thread says bye." );
+        }, event -> {
+            log.trace( "Welcome back on eventloop-thread." );
+            if( log.isDebugEnabled() ){
+                final long durationMillis = System.currentTimeMillis() - startTimeMillis;
+                log.debug( "List directory contents of '{}' took {}ms", path, durationMillis );
+            }
+            if( event.failed() ){
+                log.error( "Directory listing failed." , event.cause() );
+                final Resource erroneousResource = new Resource(){{
+                    // Set fields according to documentation in Resource class.
+                    name = Paths.get(path).getFileName().toString();
+                    exists = false;
+                    error = rejected = invalid = true;
+                    errorMessage = invalidMessage = event.cause().getMessage();
+                }};
+                handler.handle( erroneousResource );
+            }else{
+                handler.handle( (Resource)event.result() );
+            }
+        });
+        log.trace( "Work delegated." );
+    }
+
+    private void listDirBlocking(String path, int offset, int count, Future<CollectionResource> future) {
+        //
+        // HINT: This method gets executed on a worker thread!
+        //
+        // Convert String to Path
+        final Path searchPath = Paths.get(canonicalizeVirtualPath(path));
+        // Prepare our result.
+        final CollectionResource collection = new CollectionResource(){{
+            items = new ArrayList<>( 128 );
+        }};
+        final String fullPath = canonicalizeVirtualPath(path);
+        try(Stream<Path> source = Files.list(searchPath) ){
+            source.forEach(entry -> {
+                final String entryName = entry.getFileName().toString();
+                log.trace( "Processing entry '{}'", entryName );
+                if( ".tmp".equals(entryName) && fullPath.length()==root.length() ){
+                    // Ignore hidden '/.tmp/' directory.
+                    return;
+                }
+                // Create resource representing currently processed directory entry.
+                final Resource resource;
+                if( Files.isDirectory(entry) ){
+                    resource = new CollectionResource();
+                }else if( Files.isRegularFile(entry) ){
+                    resource = new DocumentResource();
+                }else{
+                    resource = new Resource();
+                    resource.exists = false;
+                }
+                resource.name = entryName;
+                collection.items.add( resource );
+            });
+        }catch( IOException e ){
+            future.fail( e );
+            return;
+        }
+        Collections.sort( collection.items );
+        // Don't know exactly what we do here now. Seems we check 'limit' for a range request.
+        int n = count;
+        if(n == -1) {
+            n = collection.items.size();
+        }
+        // Don't know exactly what we do here. But it seems we evaluate 'start' of a range request.
+        if(offset > -1) {
+            if(offset >= collection.items.size() || (offset+n) >= collection.items.size() || (offset == 0 && n == -1)) {
+                future.complete( collection );
+            } else {
+                collection.items = collection.items.subList(offset, offset+n);
+                future.complete( collection );
+            }
+        }else{
+            // TODO: Resolve future
+            //       Previous implementation did nothing here. Why? Should we do something here?
+            //       See: "https://github.com/hiddenalpha/vertx-rest-storage/blob/v2.5.2/src/main/java/org/swisspush/reststorage/FileSystemStorage.java#L77"
+            log.warn( "May we should do something here. I've no idea why old implementation did nothing." );
+        }
+    }
+
+    private String canonicalizeVirtualPath(String path) {
+        return canonicalizeRealPath(root + path);
+    }
+
+    private static String canonicalizeRealPath(String path) {
+        try {
+            return new File(path).getCanonicalPath();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/org/swisspush/reststorage/FileSystemStorage.java
+++ b/src/main/java/org/swisspush/reststorage/FileSystemStorage.java
@@ -62,7 +62,7 @@ public class FileSystemStorage implements Storage {
                 fileSystem().props(fullPath, filePropsAsyncResult -> {
                     final FileProps props = filePropsAsyncResult.result();
                     if (props.isDirectory()) {
-                        fileSystemDirLister.handleListingRequest( path , offset , count , handler );
+                        fileSystemDirLister.handleListingRequest(path, offset, count, handler);
                     } else if (props.isRegularFile()) {
                         fileSystem().open(fullPath, new OpenOptions(), event1 -> {
                             DocumentResource d = new DocumentResource();

--- a/src/main/java/org/swisspush/reststorage/FileSystemStorage.java
+++ b/src/main/java/org/swisspush/reststorage/FileSystemStorage.java
@@ -14,8 +14,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.NoSuchFileException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,13 +21,15 @@ import java.util.Optional;
 public class FileSystemStorage implements Storage {
 
     private final String root;
-    private Vertx vertx;
+    private final Vertx vertx;
     private final int rootLen;
+    private final FileSystemDirLister fileSystemDirLister;
 
     private Logger log = LoggerFactory.getLogger(FileSystemStorage.class);
 
     public FileSystemStorage(Vertx vertx, String root) {
         this.vertx = vertx;
+        this.fileSystemDirLister = new FileSystemDirLister(vertx, root);
         // Unify format for simpler work.
         String tmpRoot;
         try {
@@ -62,49 +62,7 @@ public class FileSystemStorage implements Storage {
                 fileSystem().props(fullPath, filePropsAsyncResult -> {
                     final FileProps props = filePropsAsyncResult.result();
                     if (props.isDirectory()) {
-                        fileSystem().readDir(fullPath, event1 -> {
-                            final int length = event1.result().size();
-                            final CollectionResource c = new CollectionResource();
-                            c.items = new ArrayList<>(length);
-                            if (length == 0) {
-                                handler.handle(c);
-                                return;
-                            }
-                            final int dirLength = fullPath.length();
-                            for (final String item : event1.result()) {
-                                fileSystem().props(item, itemProp -> {
-                                    Resource r;
-                                    if (itemProp.succeeded() && itemProp.result().isDirectory()) {
-                                        r = new CollectionResource();
-                                    } else if (itemProp.succeeded() && itemProp.result().isRegularFile()) {
-                                        r = new DocumentResource();
-                                    } else {
-                                        r = new Resource();
-                                        r.exists = false;
-                                    }
-                                    r.name = item.substring(dirLength + 1);
-                                    c.items.add(r);
-                                    if (c.items.size() == length) {
-                                        // Remove hidden '/.tmp/' directory.
-                                        c.items.removeIf( node -> ".tmp".equals(node.name) && dirLength==root.length() );
-                                        //
-                                        Collections.sort(c.items);
-                                        int n = count;
-                                        if(n == -1) {
-                                            n = length;
-                                        }
-                                        if(offset > -1) {
-                                            if(offset >= c.items.size() || (offset+n) >= c.items.size() || (offset == 0 && n == -1)) {
-                                                handler.handle(c);
-                                            } else {
-                                                c.items = c.items.subList(offset, offset+n);
-                                                handler.handle(c);
-                                            }
-                                        }
-                                    }
-                                });
-                            }
-                        });
+                        fileSystemDirLister.handleListingRequest( path , offset , count , handler );
                     } else if (props.isRegularFile()) {
                         fileSystem().open(fullPath, new OpenOptions(), event1 -> {
                             DocumentResource d = new DocumentResource();


### PR DESCRIPTION
- Use java.nio.file to get required infomration
- Use a vertx worker thread to keep event loop responsive

This hopefully increases performance somewhat when listing large
directories in filesystem storage. But much more important: It makes use
of workers to relax the event loop thread.

Fixes #69.