### PR TITLE
Issue #79: Open a file 'read only' for http-GET

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
 services:

--- a/src/main/java/org/swisspush/reststorage/FileSystemStorage.java
+++ b/src/main/java/org/swisspush/reststorage/FileSystemStorage.java
@@ -69,6 +69,7 @@ public class FileSystemStorage implements Storage {
                         fileSystem().open(fullPath, OPEN_OPTIONS_READ_ONLY, event1 -> {
                             DocumentResource d = new DocumentResource();
                             if (event1.failed()) {
+                                log.warn("Failed to open {} for read", fullPath, event1.cause());
                                 d.error = true;
                                 d.errorMessage = event1.cause().getMessage();
                             } else {


### PR DESCRIPTION
Main change is an optimized `OpenOptions` object to enable file-read on
read-only file-systems (or if we don't have write access rights).

Additionally a 'failed' FileOpen-Event is now handled and
returns a "500 internal server error". In previous implementation there
was *no* http-response at all, leading to timeouts in clients

solves #79